### PR TITLE
Remove ug_theme_file_icon.

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -810,30 +810,6 @@ function ug_theme_pager($variables) {
 }
 
 /**
- * Override File module to add alternative text
- * Source: modules/file/file.module
- *
- * Returns HTML for an image with an appropriate icon for the given file.
- *
- * @param $variables
- *   An associative array containing:
- *   - file: A file object for which to make an icon.
- *   - icon_directory: (optional) A path to a directory of icons to be used for
- *     files. Defaults to the value of the "file_icon_directory" variable.
- *
- * @ingroup themeable
- */
-function ug_theme_file_icon($variables) {
-  $file = $variables['file'];
-  $icon_directory = $variables['icon_directory'];
-
-  $mime = check_plain($file->filemime);
-  $icon_url = file_icon_url($file, $icon_directory);
-  /* OVERRIDE - Add alternative text */
-  return '<img class="file-icon" alt="' . $mime . '" title="' . $mime . '" src="' . $icon_url . '" />';
-}
-
-/**
  * Override search module to add label 
  * Source: https://www.drupal.org/node/2540856 
  */


### PR DESCRIPTION
Fixes #191 

theme_file_icon was overridden in ug_theme to provide file icon
alt text. This has since been fixed in Drupal core
(see: https://www.drupal.org/node/2163209).

The default implementation of theme_file_icon now provides alt
text, and converts common file types to human readable text
(e.g. 'application/vnd.ms-powerpoint' => 'Office spreadsheet icon').
Unknown file types receive a generic "file icon".

Our version used the mime type for alt text, which was not very
useful.