### PR TITLE
Move navbar button after brand in global navbar.

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
@@ -3,8 +3,9 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="container-fluid">
       <div class="navbar-header">
+        <a class="navbar-brand" href="http://www.uoguelph.ca/"><img alt="University of Guelph" src="//www.uoguelph.ca/img/universityofguelph.gif"></a>
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#ug-navbar" aria-expanded="false" aria-controls="navbar"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button>
-        <a class="navbar-brand" href="http://www.uoguelph.ca/"><img alt="University of Guelph" src="//www.uoguelph.ca/img/universityofguelph.gif"></a> </div>
+      </div>
       <div id="ug-navbar" class="navbar-collapse collapse">
 
         <ul class="nav navbar-nav navbar-right navbar-small">


### PR DESCRIPTION
Moved the menu expand/collapse button after the "brand" (U of G logo)
in the global (red) navbar menu. Previously the button was before
the brand in document order (as it is in the Bootstrap navbar
documentation). This looks okay, but it means that when you navigating
with the keyboard the "new" menu items that are added when you click
the expand button do not immediately follow the button (in document
order) which violates WCAG SCR26
(http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/SCR26.html)

The new ordering looks the same but is more accessible.

Fixes issue #125.