### PR TITLE
(Migrate D7) Add File migration class + file attachment migration for Page, News, Events

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
+++ b/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
@@ -17,6 +17,12 @@
     'role_mappings' => $role_mappings,
   );
 
+  /* FILE SETTINGS */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
   /* TAXONOMY Settings */
   $term_arguments = array(
     'source_term_keyword' => 'tags',

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
@@ -40,6 +40,12 @@ function ug_migrate_d7_migrate_api() {
 
   $event_multipart_arguments = array();
 
+  /* FILE VARIABLES */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
   /* USER VARIABLES */
   $user_arguments = array(
     'role_mappings' => array(),
@@ -110,6 +116,14 @@ function ug_migrate_d7_migrate_api() {
         'class_name' => 'UGTerm7Migration',
         'source_vocabulary' => $term_arguments['source_term_keyword'], 
         'destination_vocabulary' => 'tags',
+      ),
+
+      /**** FILE migration ****/
+      'UGFile7' => $node_arguments + array(
+        'description' => t('Migration of files from Drupal 7'),
+        'class_name' => 'UGFile7Migration',
+        'source_dir' => $file_arguments['source_directory'],
+        'destination_dir' => $file_arguments['destination_directory'],
       ),
 
       /**** PAGE migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
@@ -139,6 +139,7 @@ function ug_migrate_d7_migrate_api() {
         'class_name' => 'UGPage7Migration',
         'source_type' => $page_arguments['source_page_node_type'], 
         'destination_type' => 'page',
+        'dependencies' => array('UGFile7'),
       ),
 
       /**** NEWS migration ****/
@@ -161,6 +162,7 @@ function ug_migrate_d7_migrate_api() {
         'class_name' => 'UGNews7Migration',
         'source_type' => $news_arguments['source_news_node_type'], 
         'destination_type' => 'news',
+        'dependencies' => array('UGFile7'),
       ),
 
       /**** EVENT migration ****/
@@ -196,6 +198,7 @@ function ug_migrate_d7_migrate_api() {
         'class_name' => 'UGEvent7Migration',
         'source_type' => $event_arguments['source_event_node_type'], 
         'destination_type' => 'event',
+        'dependencies' => array('UGFile7'),
       ),
 
       /**** MENU migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -1,5 +1,7 @@
 <?php 
 
+/* NODE classes */
+
 class UGEvent7Migration extends DrupalNode7Migration {
 	public function __construct($arguments) {
 
@@ -253,11 +255,20 @@ class UGPage7Migration extends DrupalNode7Migration {
 			->defaultValue('tid');
 
 		/* Page File Attachments */
-	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments']);
-
+	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments'])
+		    ->sourceMigration('UGFile7');
+		$this->addFieldMapping('field_page_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_page_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_page_attachments:description', $page_arguments['source_page_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_page_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
 	}
 }
 
+/* TERM classes */
 
 class UGEventHeading7Migration extends DrupalTerm7Migration {
 	public function __construct($arguments) {
@@ -306,4 +317,11 @@ class UGTerm7Migration extends DrupalTerm7Migration {
     	parent::__construct($arguments);
 
 	}	
+}
+
+/* FILE classes */
+class UGFile7Migration extends DrupalFile7Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+	}
 }

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -57,8 +57,19 @@ class UGEvent7Migration extends DrupalNode7Migration {
 		$this->addFieldMapping('field_event_image', $event_arguments['source_event_image']);
 		$this->addFieldMapping('field_event_multipart', $event_arguments['source_event_multipart']);
 		$this->addFieldMapping('field_event_caption', $event_arguments['source_event_caption']);
-		$this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments']);
 		$this->addFieldMapping('field_event_link', $event_arguments['source_event_link']);
+
+		/* Event File Attachments */
+	    $this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments'])
+		    ->sourceMigration('UGFile7');
+		$this->addFieldMapping('field_event_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_event_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_event_attachments:description', $event_arguments['source_event_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_event_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
 	}
 }
 
@@ -202,7 +213,19 @@ class UGNews7Migration extends DrupalNode7Migration {
 	    $this->addFieldMapping('field_news_link', $news_arguments['source_news_link']);
 	    $this->addFieldMapping('field_news_image', $news_arguments['source_news_image']);
 	    $this->addFieldMapping('field_news_caption', $news_arguments['source_news_caption']);
-	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment']);
+	    //$this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment']);
+
+		/* News File Attachments */
+	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment'])
+		    ->sourceMigration('UGFile7');
+		$this->addFieldMapping('field_news_attachment:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_news_attachment:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_news_attachment:description', $news_arguments['source_news_attachment'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_news_attachment:language')
+	        ->defaultValue(LANGUAGE_NONE);
 
 	}
 }

--- a/sites/all/modules/field_collection/field_collection.module
+++ b/sites/all/modules/field_collection/field_collection.module
@@ -827,7 +827,9 @@ function field_collection_item_access($op, FieldCollectionItemEntity $item = NUL
  */
 function field_collection_item_delete($id) {
   $fci = field_collection_item_load($id);
-  $fci->delete();
+  if($fci) {
+    $fci->delete();
+  }
 }
 
 /**


### PR DESCRIPTION
Adds file attachment migration class. I've tested this on Business and Biophysics using the following procedure:

1. Move over the files manually to the /files directory under the site directory
2. drush mi UGFile7
3. drush mi --update UGPage7
4. drush mi --update UGNews7

Note: Includes patch on Field Collection to avoid deleting field collections if they do not exist.

**Update:** Fixes #336 by making the node migrations dependent on the file migration.