### PR TITLE
(Migrate D6) Add File migration class + file attachment migration for Page, News, Events

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -19,6 +19,12 @@
     'picture_destination' => 'public://',
   );
 
+  /* FILE SETTINGS */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
   /* TAXONOMY Settings */
   $term_arguments = array(
     'source_term_keyword' => 'tags',
@@ -34,7 +40,7 @@
     'source_page_format' => 'body:format',
     'source_page_category' => '',
     'source_page_keyword' => 'field_tags',
-    'source_page_attachments' => '',
+    'source_page_attachments' => 'upload',
   );
   
   /* NEWS Settings */
@@ -51,7 +57,7 @@
     'source_news_link' => '',
     'source_news_image' => '',
     'source_news_caption' => '',
-    'source_news_attachment' => '',
+    'source_news_attachment' => 'upload',
   );
 
   /* EVENT Settings */
@@ -72,7 +78,7 @@
     'source_event_multipart_content' => '',
     'source_event_image' => '',
     'source_event_caption' => '',
-    'source_event_attachments' => '',
+    'source_event_attachments' => 'upload',
     'source_event_link' => '',
   );
 

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -47,6 +47,13 @@ function ug_migrate_d6_migrate_api() {
     'picture_destination' => 'public://',
   );
 
+  /* FILE VARIABLES */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
+
   /* TAXONOMY VARIABLES */
   $term_arguments = array(
     'source_term_keyword' => 'tags',
@@ -122,6 +129,14 @@ function ug_migrate_d6_migrate_api() {
         'destination_vocabulary' => 'tags',
       ),
 
+      /**** FILE migration ****/
+      'UGFile6' => $node_arguments + array(
+        'description' => t('Migration of files from Drupal 6'),
+        'class_name' => 'UGFile6Migration',
+        'source_dir' => $file_arguments['source_directory'],
+        'destination_dir' => $file_arguments['destination_directory'],
+      ),
+
       /**** PAGE migration ****/
       'UGPageCategory6' => $common_arguments + array(
         'description' => t('Migration of page category terms from Drupal 6'),
@@ -135,6 +150,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGPage6Migration',
         'source_type' => $page_arguments['source_page_node_type'], 
         'destination_type' => 'page',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** NEWS migration ****/
@@ -157,6 +173,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGNews6Migration',
         'source_type' => $news_arguments['source_news_node_type'], 
         'destination_type' => 'news',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** EVENT migration ****/
@@ -192,6 +209,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGEvent6Migration',
         'source_type' => $event_arguments['source_event_node_type'], 
         'destination_type' => 'event',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** MENU migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -53,8 +53,21 @@ class UGEvent6Migration extends DrupalNode6Migration {
 		$this->addFieldMapping('field_event_multipart', $event_arguments['source_event_multipart']);
 		$this->addFieldMapping('field_event_image', $event_arguments['source_event_image']);
 		$this->addFieldMapping('field_event_caption', $event_arguments['source_event_caption']);
-		$this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments']);
 		$this->addFieldMapping('field_event_link', $event_arguments['source_event_link']);
+
+		/* Event File Attachments */
+		$this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_event_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_event_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_event_attachments:description', $event_arguments['source_event_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_event_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
+
+
 	}
 }
 
@@ -198,7 +211,18 @@ class UGNews6Migration extends DrupalNode6Migration {
 	    $this->addFieldMapping('field_news_link', $news_arguments['source_news_link']);
 	    $this->addFieldMapping('field_news_image', $news_arguments['source_news_image']);
 	    $this->addFieldMapping('field_news_caption', $news_arguments['source_news_caption']);
-	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment']);
+
+		/* News File Attachments */
+	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_news_attachment:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_news_attachment:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_news_attachment:description', $news_arguments['source_news_attachment'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_news_attachment:language')
+	        ->defaultValue(LANGUAGE_NONE);
 
 	}
 }
@@ -244,8 +268,17 @@ class UGPage6Migration extends DrupalNode6Migration {
 		$this->addFieldMapping('field_tags:source_type')
 			->defaultValue('tid');
 
-		/* Page File Attachment */
-	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments']);
+		/* Page File Attachments */
+	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_page_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_page_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_page_attachments:description', $page_arguments['source_page_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_page_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
 	}
 }
 
@@ -275,26 +308,33 @@ class UGNewsCategory6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGNewsKeyword6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGPageCategory6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGTerm6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
+}
+
+/* FILE classes */
+class UGFile6Migration extends DrupalFile6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+	}
 }


### PR DESCRIPTION
Add file attachment field migrations to Page, News, and Events migrations for D6. 

Tested successfully on local machine.

At the moment, I'm not seeing any D6 to D7 sites with file attachments, so testing will be limited to whether UGFile6 successfully brings over the files. By default, I am pulling in the files from the upload table, however, if you find that files are not coming through, check to see if you need to reference a different source table for the attachments.