### PR TITLE
(Migrate D6) Add Feature Image migration to News, Event

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -19,6 +19,12 @@
     'picture_destination' => 'public://',
   );
 
+  /* FILE SETTINGS */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
   /* TAXONOMY Settings */
   $term_arguments = array(
     'source_term_keyword' => 'tags',
@@ -34,7 +40,7 @@
     'source_page_format' => 'body:format',
     'source_page_category' => '',
     'source_page_keyword' => 'field_tags',
-    'source_page_attachments' => '',
+    'source_page_attachments' => 'upload',
   );
   
   /* NEWS Settings */
@@ -51,7 +57,7 @@
     'source_news_link' => '',
     'source_news_image' => '',
     'source_news_caption' => '',
-    'source_news_attachment' => '',
+    'source_news_attachment' => 'upload',
   );
 
   /* EVENT Settings */
@@ -72,7 +78,7 @@
     'source_event_multipart_content' => '',
     'source_event_image' => '',
     'source_event_caption' => '',
-    'source_event_attachments' => '',
+    'source_event_attachments' => 'upload',
     'source_event_link' => '',
   );
 

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -137,6 +137,13 @@ function ug_migrate_d6_migrate_api() {
         'destination_dir' => $file_arguments['destination_directory'],
       ),
 
+      'UGImage6' => $node_arguments + array(
+        'description' => t('Migration of images from Drupal 6'),
+        'class_name' => 'UGImage6Migration',
+        'source_dir' => $file_arguments['source_directory'],
+        'destination_dir' => $file_arguments['destination_directory'],
+      ),
+
       /**** PAGE migration ****/
       'UGPageCategory6' => $common_arguments + array(
         'description' => t('Migration of page category terms from Drupal 6'),
@@ -173,7 +180,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGNews6Migration',
         'source_type' => $news_arguments['source_news_node_type'], 
         'destination_type' => 'news',
-        'dependencies' => array('UGFile6'),
+        'dependencies' => array('UGFile6','UGImage6'),
       ),
 
       /**** EVENT migration ****/
@@ -209,7 +216,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGEvent6Migration',
         'source_type' => $event_arguments['source_event_node_type'], 
         'destination_type' => 'event',
-        'dependencies' => array('UGFile6'),
+        'dependencies' => array('UGFile6', 'UGImage6'),
       ),
 
       /**** MENU migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -47,6 +47,13 @@ function ug_migrate_d6_migrate_api() {
     'picture_destination' => 'public://',
   );
 
+  /* FILE VARIABLES */
+  $file_arguments = array(
+    'source_directory' => 'public://',
+    'destination_directory' => 'public://',
+  );
+
+
   /* TAXONOMY VARIABLES */
   $term_arguments = array(
     'source_term_keyword' => 'tags',
@@ -122,6 +129,14 @@ function ug_migrate_d6_migrate_api() {
         'destination_vocabulary' => 'tags',
       ),
 
+      /**** FILE migration ****/
+      'UGFile6' => $node_arguments + array(
+        'description' => t('Migration of files from Drupal 6'),
+        'class_name' => 'UGFile6Migration',
+        'source_dir' => $file_arguments['source_directory'],
+        'destination_dir' => $file_arguments['destination_directory'],
+      ),
+
       /**** PAGE migration ****/
       'UGPageCategory6' => $common_arguments + array(
         'description' => t('Migration of page category terms from Drupal 6'),
@@ -135,6 +150,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGPage6Migration',
         'source_type' => $page_arguments['source_page_node_type'], 
         'destination_type' => 'page',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** NEWS migration ****/
@@ -157,6 +173,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGNews6Migration',
         'source_type' => $news_arguments['source_news_node_type'], 
         'destination_type' => 'news',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** EVENT migration ****/
@@ -192,6 +209,7 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGEvent6Migration',
         'source_type' => $event_arguments['source_event_node_type'], 
         'destination_type' => 'event',
+        'dependencies' => array('UGFile6'),
       ),
 
       /**** MENU migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -451,40 +451,54 @@ class UGImage6Migration extends DrupalFile6Migration {
     if (parent::prepareRow($row) === FALSE) {
       return FALSE;
     }
-    
-    /* Image Attach Query */
-    $query = Database::getConnection('default', $this->sourceConnection)
-      ->select('image_attach', 'ia')
-      ->fields('ia', array('nid'));
-    $query->innerJoin('image', 'i', 'ia.iid=i.nid');
-    $query->condition('i.fid', $row->fid);
-    $query->condition('image_size', '_original');
-    $node = $query->execute()->fetchObject();
 
-    if ($node) {
-      $nid = strval($node->nid);
-      $pathinfo = pathinfo($row->filepath);
-      $filename = $pathinfo['filename'];
-      $extension = $pathinfo['extension'];
-      $row->filename = $nid . '.' . $extension;
+    //Check if Image Attach module exists
+    $queryImageAttach = Database::getConnection('default',$this->sourceConnection)
+    	->schema()
+    	->tableExists('image_attach');
+
+	//Check if Image Assist module exists
+    $queryImageAssist = Database::getConnection('default',$this->sourceConnection)
+    	->schema()
+    	->tableExists('img_assist_map');
+
+    /* Image Attach Query */
+    if($queryImageAttach == TRUE){
+	    $query = Database::getConnection('default', $this->sourceConnection)
+	      ->select('image_attach', 'ia')
+	      ->fields('ia', array('nid'));
+	    $query->innerJoin('image', 'i', 'ia.iid=i.nid');
+	    $query->condition('i.fid', $row->fid);
+	    $query->condition('image_size', '_original');
+	    $node = $query->execute()->fetchObject();
+
+	    if ($node) {
+	      $nid = strval($node->nid);
+	      $pathinfo = pathinfo($row->filepath);
+	      $filename = $pathinfo['filename'];
+	      $extension = $pathinfo['extension'];
+	      $row->filename = $nid . '.' . $extension;
+	    }
     }
 
 	/* Image Assist Query */
-    $query2 = Database::getConnection('default', $this->sourceConnection)
-      ->select('img_assist_map', 'im')
-      ->fields('im', array('nid'));
-    $query2->innerJoin('image', 'i', 'im.iid=i.nid');
-    $query2->condition('i.fid', $row->fid);
-    $query2->condition('image_size', '_original');
-    $node2 = $query2->execute()->fetchObject();
+    if($queryImageAssist == TRUE){
+	    $query2 = Database::getConnection('default', $this->sourceConnection)
+	      ->select('img_assist_map', 'im')
+	      ->fields('im', array('nid'));
+	    $query2->innerJoin('image', 'i', 'im.iid=i.nid');
+	    $query2->condition('i.fid', $row->fid);
+	    $query2->condition('image_size', '_original');
+	    $node2 = $query2->execute()->fetchObject();
 
-    if ($node2) {
-      $nid = strval($node2->nid);
-      $pathinfo = pathinfo($row->filepath);
-      $filename = $pathinfo['filename'];
-      $extension = $pathinfo['extension'];
-      $row->filename = $nid . '.' . $extension;
-    }
+	    if ($node2) {
+	      $nid = strval($node2->nid);
+	      $pathinfo = pathinfo($row->filepath);
+	      $filename = $pathinfo['filename'];
+	      $extension = $pathinfo['extension'];
+	      $row->filename = $nid . '.' . $extension;
+	    }
+	}
 
 
   }

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -452,6 +452,7 @@ class UGImage6Migration extends DrupalFile6Migration {
       return FALSE;
     }
     
+    /* Image Attach Query */
     $query = Database::getConnection('default', $this->sourceConnection)
       ->select('image_attach', 'ia')
       ->fields('ia', array('nid'));
@@ -459,7 +460,7 @@ class UGImage6Migration extends DrupalFile6Migration {
     $query->condition('i.fid', $row->fid);
     $query->condition('image_size', '_original');
     $node = $query->execute()->fetchObject();
-    
+
     if ($node) {
       $nid = strval($node->nid);
       $pathinfo = pathinfo($row->filepath);
@@ -467,5 +468,24 @@ class UGImage6Migration extends DrupalFile6Migration {
       $extension = $pathinfo['extension'];
       $row->filename = $nid . '.' . $extension;
     }
+
+	/* Image Assist Query */
+    $query2 = Database::getConnection('default', $this->sourceConnection)
+      ->select('img_assist_map', 'im')
+      ->fields('im', array('nid'));
+    $query2->innerJoin('image', 'i', 'im.iid=i.nid');
+    $query2->condition('i.fid', $row->fid);
+    $query2->condition('image_size', '_original');
+    $node2 = $query2->execute()->fetchObject();
+
+    if ($node2) {
+      $nid = strval($node2->nid);
+      $pathinfo = pathinfo($row->filepath);
+      $filename = $pathinfo['filename'];
+      $extension = $pathinfo['extension'];
+      $row->filename = $nid . '.' . $extension;
+    }
+
+
   }
 }

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -16,7 +16,7 @@ class UGEvent6Migration extends DrupalNode6Migration {
 			'source_event_date' => '',
 			'source_event_location' => '',
 			'source_event_multipart' => '',
-			'source_event_image' => '',
+			'source_event_image' => 'fid',
 			'source_event_caption' => '',
 			'source_event_attachments' => '',
 			'source_event_link' => '',
@@ -25,7 +25,9 @@ class UGEvent6Migration extends DrupalNode6Migration {
 		//Override default values with arguments if they exist
 		foreach ($event_arguments as $key => $value) {
 		    if(isset($this->arguments[$key])){
-		    	$event_arguments[$key] = $this->arguments[$key];
+		    	if($this->arguments[$key]!=''){
+			    	$event_arguments[$key] = $this->arguments[$key];
+		    	}
 		    }
 		}
 
@@ -51,7 +53,6 @@ class UGEvent6Migration extends DrupalNode6Migration {
 		$this->addFieldMapping('field_event_date', $event_arguments['source_event_date']);
 		$this->addFieldMapping('field_event_location', $event_arguments['source_event_location']);
 		$this->addFieldMapping('field_event_multipart', $event_arguments['source_event_multipart']);
-		$this->addFieldMapping('field_event_image', $event_arguments['source_event_image']);
 		$this->addFieldMapping('field_event_caption', $event_arguments['source_event_caption']);
 		$this->addFieldMapping('field_event_link', $event_arguments['source_event_link']);
 
@@ -67,8 +68,42 @@ class UGEvent6Migration extends DrupalNode6Migration {
 	    $this->addFieldMapping('field_event_attachments:language')
 	        ->defaultValue(LANGUAGE_NONE);
 
-
+		/* Event Featured Image */
+	    $this->addFieldMapping('field_event_image', $event_arguments['source_event_image']);
+		$this->addFieldMapping('field_event_image:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_event_image:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_event_image:alt', $event_arguments['source_event_image'] . ':alt')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_event_image:title', $event_arguments['source_event_image'] . ':title')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_event_image:language')
+	        ->defaultValue(LANGUAGE_NONE);
 	}
+
+  
+  /**
+   * Implementation of Migration::prepareRow().
+   */
+  public function prepareRow($row) {
+    if (parent::prepareRow($row) === FALSE) {
+      return FALSE;
+    }
+    // image query
+    $pattern = strval($row->nid) . '.%';
+    $image = Database::getConnection('default', 'default')
+      ->select('file_managed', 'f')
+      ->fields('f', array('fid'))
+      ->condition('filename', $pattern, 'LIKE')
+      ->execute()
+      ->fetchObject();
+
+    if ($image) {
+      $row->fid = array($image->fid);
+	  //drush_print_r($row);
+    }
+  }
 }
 
 
@@ -176,7 +211,7 @@ class UGNews6Migration extends DrupalNode6Migration {
 			'source_news_keyword' => '',
 			'source_news_writer' => '',
 			'source_news_link' => '',
-			'source_news_image' => '',
+			'source_news_image' => 'fid',
 			'source_news_caption' => '',
 			'source_news_attachment' => '',
 		);
@@ -184,7 +219,9 @@ class UGNews6Migration extends DrupalNode6Migration {
 		//Override default values with arguments if they exist
 		foreach ($news_arguments as $key => $value) {
 		    if(isset($this->arguments[$key])){
-		    	$news_arguments[$key] = $this->arguments[$key];
+		    	if($this->arguments[$key]!=''){
+			    	$news_arguments[$key] = $this->arguments[$key];
+			    }
 		    }
 		}
 
@@ -209,7 +246,6 @@ class UGNews6Migration extends DrupalNode6Migration {
 		/* News Fields */
 	    $this->addFieldMapping('field_news_writer', $news_arguments['source_news_writer']);
 	    $this->addFieldMapping('field_news_link', $news_arguments['source_news_link']);
-	    $this->addFieldMapping('field_news_image', $news_arguments['source_news_image']);
 	    $this->addFieldMapping('field_news_caption', $news_arguments['source_news_caption']);
 
 		/* News File Attachments */
@@ -224,8 +260,46 @@ class UGNews6Migration extends DrupalNode6Migration {
 	    $this->addFieldMapping('field_news_attachment:language')
 	        ->defaultValue(LANGUAGE_NONE);
 
+		/* News Featured Image */
+	    $this->addFieldMapping('field_news_image', $news_arguments['source_news_image']);
+		$this->addFieldMapping('field_news_image:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_news_image:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_news_image:alt', $news_arguments['source_news_image'] . ':alt')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_news_image:title', $news_arguments['source_news_image'] . ':title')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_news_image:language')
+	        ->defaultValue(LANGUAGE_NONE);
+
 	}
+
+  
+  /**
+   * Implementation of Migration::prepareRow().
+   */
+  public function prepareRow($row) {
+    if (parent::prepareRow($row) === FALSE) {
+      return FALSE;
+    }
+    // image query
+    $pattern = strval($row->nid) . '.%';
+    $image = Database::getConnection('default', 'default')
+      ->select('file_managed', 'f')
+      ->fields('f', array('fid'))
+      ->condition('filename', $pattern, 'LIKE')
+      ->execute()
+      ->fetchObject();
+
+    if ($image) {
+      $row->fid = array($image->fid);
+	  //drush_print_r($row);
+    }
+  }
+
 }
+
 
 class UGPage6Migration extends DrupalNode6Migration {
 	public function __construct($arguments) {
@@ -337,4 +411,61 @@ class UGFile6Migration extends DrupalFile6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 	}
+
+	public function prepareRow($row) {
+		if (parent::prepareRow($row) === FALSE) {
+		    return FALSE;
+		}
+	    
+	    //drush_print_r($row);
+	}
+}
+
+
+/**
+ * Handling specific to a Drupal 6 source for images.
+ */
+class UGImage6Migration extends DrupalFile6Migration {
+  /**
+   * @param array $arguments
+   */
+  public function __construct(array $arguments) {
+    $this->sourceFields['filename'] = 'converted filename';
+    parent::__construct($arguments);
+
+    $this->addFieldMapping('destination_file', 'filename');
+  }
+  
+  protected function query() {
+    $query = parent::query();
+    
+    $query->innerJoin('image', 'i', 'f.fid=i.fid');
+    $query->condition('image_size', '_original');
+    return $query;
+  }
+  
+  /**
+   * Implementation of Migration::prepareRow().
+   */
+  public function prepareRow($row) {
+    if (parent::prepareRow($row) === FALSE) {
+      return FALSE;
+    }
+    
+    $query = Database::getConnection('default', $this->sourceConnection)
+      ->select('image_attach', 'ia')
+      ->fields('ia', array('nid'));
+    $query->innerJoin('image', 'i', 'ia.iid=i.nid');
+    $query->condition('i.fid', $row->fid);
+    $query->condition('image_size', '_original');
+    $node = $query->execute()->fetchObject();
+    
+    if ($node) {
+      $nid = strval($node->nid);
+      $pathinfo = pathinfo($row->filepath);
+      $filename = $pathinfo['filename'];
+      $extension = $pathinfo['extension'];
+      $row->filename = $nid . '.' . $extension;
+    }
+  }
 }

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -53,8 +53,21 @@ class UGEvent6Migration extends DrupalNode6Migration {
 		$this->addFieldMapping('field_event_multipart', $event_arguments['source_event_multipart']);
 		$this->addFieldMapping('field_event_image', $event_arguments['source_event_image']);
 		$this->addFieldMapping('field_event_caption', $event_arguments['source_event_caption']);
-		$this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments']);
 		$this->addFieldMapping('field_event_link', $event_arguments['source_event_link']);
+
+		/* Event File Attachments */
+		$this->addFieldMapping('field_event_attachments', $event_arguments['source_event_attachments'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_event_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_event_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_event_attachments:description', $event_arguments['source_event_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_event_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
+
+
 	}
 }
 
@@ -198,7 +211,18 @@ class UGNews6Migration extends DrupalNode6Migration {
 	    $this->addFieldMapping('field_news_link', $news_arguments['source_news_link']);
 	    $this->addFieldMapping('field_news_image', $news_arguments['source_news_image']);
 	    $this->addFieldMapping('field_news_caption', $news_arguments['source_news_caption']);
-	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment']);
+
+		/* News File Attachments */
+	    $this->addFieldMapping('field_news_attachment', $news_arguments['source_news_attachment'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_news_attachment:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_news_attachment:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_news_attachment:description', $news_arguments['source_news_attachment'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_news_attachment:language')
+	        ->defaultValue(LANGUAGE_NONE);
 
 	}
 }
@@ -244,8 +268,17 @@ class UGPage6Migration extends DrupalNode6Migration {
 		$this->addFieldMapping('field_tags:source_type')
 			->defaultValue('tid');
 
-		/* Page File Attachment */
-	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments']);
+		/* Page File Attachments */
+	    $this->addFieldMapping('field_page_attachments', $page_arguments['source_page_attachments'])
+		    ->sourceMigration('UGFile6');
+		$this->addFieldMapping('field_page_attachments:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_page_attachments:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_page_attachments:description', $page_arguments['source_page_attachments'] . ':description')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_page_attachments:language')
+	        ->defaultValue(LANGUAGE_NONE);
 	}
 }
 
@@ -275,26 +308,33 @@ class UGNewsCategory6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGNewsKeyword6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGPageCategory6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
 }
 
 class UGTerm6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
-	}	
+	}
+}
+
+/* FILE classes */
+class UGFile6Migration extends DrupalFile6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+	}
 }


### PR DESCRIPTION
Adds UGImage6 class (specifically migrates items from the Image and Image Attach module and connects them up with any nodes that reference them). Relies on File migration class introduced in https://github.com/ccswbs/hjckrrh/pull/344

Connects those migrated images with News and Events.

Tested successfully on local machine. Needs a real-data migration test on one of the D6 sites.