### PR TITLE
Fix: Add end date/timezone to Event migration (Migrate D7)[fixes #349…

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
+++ b/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
@@ -70,6 +70,7 @@
     'source_event_category' => '',
     'source_event_keyword' => '',
     'source_event_date' => '',
+    'source_event_date_timezone' => 'UTC',
     'source_event_location' => '',
     'source_event_multipart' => '',
     'source_event_multipart_heading' => '',

--- a/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
+++ b/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
@@ -70,7 +70,7 @@
     'source_event_category' => '',
     'source_event_keyword' => '',
     'source_event_date' => '',
-    'source_event_date_timezone' => 'UTC',
+    'source_event_date_timezone' => 'America/New_York',
     'source_event_location' => '',
     'source_event_multipart' => '',
     'source_event_multipart_heading' => '',

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -17,6 +17,7 @@ class UGEvent7Migration extends DrupalNode7Migration {
 			'source_event_category' => '',
 			'source_event_keyword' => '',
 			'source_event_date' => '',
+			'source_event_date_timezone' => 'UTC',
 			'source_event_location' => '',
 			'source_event_multipart' => '',
 			'source_event_image' => '',
@@ -76,8 +77,13 @@ class UGEvent7Migration extends DrupalNode7Migration {
 	    $this->addFieldMapping('field_event_attachments:language')
 	        ->defaultValue(LANGUAGE_NONE);
 
-		/* Event Date, Location, Multipart Fields, Caption, Link */
+		/* Event Date */
 		$this->addFieldMapping('field_event_date', $event_arguments['source_event_date']);
+		$this->addFieldMapping('field_event_date:to', $event_arguments['source_event_date'].":value2");
+		$this->addFieldMapping('field_event_date:timezone')
+			->defaultValue($event_arguments['source_event_date_timezone']);
+
+		/* Event Location, Multipart Fields, Caption, Link */
 		$this->addFieldMapping('field_event_location', $event_arguments['source_event_location']);
 		$this->addFieldMapping('field_event_multipart', $event_arguments['source_event_multipart']);
 		$this->addFieldMapping('field_event_caption', $event_arguments['source_event_caption']);
@@ -88,15 +94,15 @@ class UGEvent7Migration extends DrupalNode7Migration {
 
 /* Troubleshooting Function -- Uncomment to print out contents of every row */
 
-/*	public function prepareRow($row){
+	/*public function prepareRow($row){
 		if(parent::prepareRow($row)===FALSE){
 			return FALSE;
 		}
 		echo("<<<<<<<");
 		drush_print_r($row);
 		echo(">>>>>>>");
-	}
-*/
+	}*/
+
 	
 
 }

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -29,7 +29,9 @@ class UGEvent7Migration extends DrupalNode7Migration {
 		//Override default values with arguments if they exist
 		foreach ($event_arguments as $key => $value) {
 		    if(isset($this->arguments[$key])){
-		    	$event_arguments[$key] = $this->arguments[$key];
+		    	if($this->arguments[$key] != ''){
+			    	$event_arguments[$key] = $this->arguments[$key];
+		    	}
 		    }
 		}
 

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -17,7 +17,7 @@ class UGEvent7Migration extends DrupalNode7Migration {
 			'source_event_category' => '',
 			'source_event_keyword' => '',
 			'source_event_date' => '',
-			'source_event_date_timezone' => 'UTC',
+			'source_event_date_timezone' => 'America/New_York',
 			'source_event_location' => '',
 			'source_event_multipart' => '',
 			'source_event_image' => '',


### PR DESCRIPTION
Fixes #349 and #350.

Recommend testing with Biophysics data to confirm whether fix works or not.

When testing, ensure that you update the site-specific migrate configuration file to include the timezone value you'd like to use for source_event_date_timezone (eg. "America/New_York")