### PR TITLE
New: Add FAQ, FAQ category/keyword migration (UG Migrate D6)[fixes #358]

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -54,6 +54,17 @@
     'source_news_attachment' => '',
   );
 
+  /* FAQ Settings */
+  $faq_arguments = array(
+    'source_faq_node_type' => '',
+    'source_faq_term_category' => '',
+    'source_faq_term_keyword' => '',
+    'source_faq_answer' => 'body',
+    'source_faq_format' => 'body:format',
+    'source_faq_category' => '',
+    'source_faq_keyword' => '',
+  );
+
   /* EVENT Settings */
   $event_arguments = array(
     'source_event_node_type' => '',

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -40,6 +40,12 @@ function ug_migrate_d6_migrate_api() {
 
   $event_multipart_arguments = array();
 
+  $faq_arguments = array(
+    'source_faq_node_type' => '',
+    'source_faq_term_category' => '',
+    'source_faq_term_keyword' => '',
+  );
+
   /* USER VARIABLES */
   $user_arguments = array(
     'role_mappings' => array(),
@@ -56,8 +62,8 @@ function ug_migrate_d6_migrate_api() {
   $menu_names = array('primary-links');
   $menu_link_arguments = array(
     'menu_migration' => 'UGMenu6',
-    'node_migrations' => array('UGPage6', 'UGNews6', 'UGEvent6'),
-    'term_migrations' => array('UGTerm6', 'UGPageCategory6', 'UGNewsCategory6', 'UGNewsKeyword6', 'UGEventCategory6', 'UGEventKeyword6'),
+    'node_migrations' => array('UGPage6', 'UGNews6', 'UGEvent6', 'UGFAQ6'),
+    'term_migrations' => array('UGTerm6', 'UGPageCategory6', 'UGNewsCategory6', 'UGNewsKeyword6', 'UGEventCategory6', 'UGEventKeyword6','UGFAQCategory6', 'UGFAQKeyword6'),
   );
 
   $menu_arguments = $common_arguments + array(
@@ -192,6 +198,28 @@ function ug_migrate_d6_migrate_api() {
         'class_name' => 'UGEvent6Migration',
         'source_type' => $event_arguments['source_event_node_type'], 
         'destination_type' => 'event',
+      ),
+
+      /**** FAQ migration ****/
+      'UGFAQKeyword6' => $common_arguments + array(
+        'description' => t('Migration of FAQ keyword terms from Drupal 6'),
+        'class_name' => 'UGFAQKeyword6Migration',
+        'source_vocabulary' => $faq_arguments['source_faq_term_keyword'],
+        'destination_vocabulary' => 'tags',
+      ),
+
+      'UGFAQCategory6' => $common_arguments + array(
+        'description' => t('Migration of FAQ category terms from Drupal 6'),
+        'class_name' => 'UGFAQCategory6Migration',
+        'source_vocabulary' => $faq_arguments['source_faq_term_category'],
+        'destination_vocabulary' => 'faq_category',
+      ),
+
+      'UGFAQ6' => $node_arguments + $faq_arguments + array(
+        'description' => t('Migration of FAQ from Drupal 6'),
+        'class_name' => 'UGFAQ6Migration',
+        'source_type' => $faq_arguments['source_faq_node_type'], 
+        'destination_type' => 'faq',
       ),
 
       /**** MENU migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -249,6 +249,59 @@ class UGPage6Migration extends DrupalNode6Migration {
 	}
 }
 
+class UGFAQ6Migration extends DrupalNode6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+
+	    $this->destination = new MigrateDestinationNode('faq');
+		
+		/* DEFAULT arguments */
+		$faq_arguments = array(
+			'source_faq_answer' => 'body',
+			'source_faq_format' => 'body:format',
+			'source_faq_category' => '',
+			'source_faq_keyword' => '',
+		);
+
+		//Override default values with arguments if they exist
+		foreach ($faq_arguments as $key => $value) {
+		    if(isset($this->arguments[$key])){
+		    	if($this->arguments[$key] != ''){
+			    	$faq_arguments[$key] = $this->arguments[$key];
+		    	}
+		    }
+		}
+
+	    /* FAQ Answer */
+	    $this->addFieldMapping('field_faq_answer', $faq_arguments['source_faq_answer']);
+	    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+		    ->callbacks(array($this, 'mapFormat'))
+		    ->defaultValue('full_html');
+
+		/* FAQ Category */
+		$this->addFieldMapping('field_faq_category', $faq_arguments['source_faq_category'])
+			->sourceMigration('UGFAQCategory6');
+		$this->addFieldMapping('field_faq_category:source_type')
+			->defaultValue('tid');
+
+		/* FAQ Keyword */
+		$this->addFieldMapping('field_tags', $faq_arguments['source_faq_keyword'])
+			->sourceMigration('UGTerm6');
+		$this->addFieldMapping('field_tags:source_type')
+			->defaultValue('tid');
+	}
+
+	/* Troubleshooting Function -- Uncomment to print out contents of every row */
+	/*public function prepareRow($row){
+		if(parent::prepareRow($row)===FALSE){
+			return FALSE;
+		}
+		echo("<<<<<<<");
+		drush_print_r($row);
+		echo(">>>>>>>");
+	}*/
+}
+
 
 class UGEventHeading6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
@@ -289,6 +342,17 @@ class UGPageCategory6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
 
+	}	
+}
+
+class UGFAQCategory6Migration extends DrupalTerm6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+	}	
+}
+class UGFAQKeyword6Migration extends DrupalTerm6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
 	}	
 }
 


### PR DESCRIPTION
Implements FAQ, FAQ category and FAQ keyword migration from Drupal 6 to Drupal 7 sites.

Works well on local machine migration. Recommend testing migration using data from CIO.

Fixes #358 