### PR TITLE
Fix: Prevents low-contrast text if #ug-header background image fails to load (UG Header)[refs #286]

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/css/style.css
+++ b/profiles/ug/themes/ug/ug_cornerstone/css/style.css
@@ -12,7 +12,7 @@
 }
 #ug-header {
 	color: #FEFEFE;
-	background: url(//www.uoguelph.ca/img/headerbg.jpg) maroon;
+	background: url(//www.uoguelph.ca/img/headerbg.jpg);
 	background-repeat: repeat-x;
 }
 #ug-header .navbar-toggle {
@@ -28,6 +28,12 @@
 #ug-header .navbar-default {
 	background: none;
 }
+
+#ug-header .navbar-default.navbar-static-top{
+  background: url(//www.uoguelph.ca/img/headerbg.jpg) black;
+  background-repeat: repeat-x;
+}
+
 #ug-header .dropdown-menu,
 #ug-header footer.navbar-default,
 #ug-header nav.navbar div.in,

--- a/profiles/ug/themes/ug/ug_cornerstone/css/style.css
+++ b/profiles/ug/themes/ug/ug_cornerstone/css/style.css
@@ -11,7 +11,8 @@
 	display: inline !important;
 }
 #ug-header {
-	background-image: url(//www.uoguelph.ca/img/headerbg.jpg);
+	color: #FEFEFE;
+	background: url(//www.uoguelph.ca/img/headerbg.jpg) maroon;
 	background-repeat: repeat-x;
 }
 #ug-header .navbar-toggle {
@@ -40,7 +41,7 @@
 	background: #000;
 	border: 000;
 }
-#ug-header .navbar-default .navbar-nav>.open>a, 
+#ug-header .navbar-default .navbar-nav>.open>a,
 #ug-header .navbar-default .navbar-nav>.open>a:hover,
 #ug-header .navbar-default .navbar-nav>.open>a:focus {
 	background: #45403a;
@@ -67,10 +68,10 @@
 }
 
 #ug-header .navbar-default .navbar-nav li a:hover,
-#ug-header .navbar-default .navbar-nav>.open>a, 
-#ug-header .navbar-default .navbar-nav>.open>a:hover, 
-#ug-header .navbar-default .navbar-nav>.open>a:focus, 
-#ug-header .navbar-default .navbar-nav .open .dropdown-menu>li>a:hover, 
+#ug-header .navbar-default .navbar-nav>.open>a,
+#ug-header .navbar-default .navbar-nav>.open>a:hover,
+#ug-header .navbar-default .navbar-nav>.open>a:focus,
+#ug-header .navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,
 #ug-header .navbar-default .navbar-nav .open .dropdown-menu>li>a:focus {
 	color: #fff
 }
@@ -117,7 +118,7 @@
 	}
 
 	#ug-header #globalnav li a,
-	#ug-header #globalnav>li>a:hover { 
+	#ug-header #globalnav>li>a:hover {
 		text-shadow: 1px 1px 0 #600, -1px -1px 0 #600, 1px -1px 0 #600, -1px 1px 0 #600, 1px 1px 0 #600 !important;
 	}
 


### PR DESCRIPTION
I've added a fallback color to `#ug-header` background to prevent contrast issues if the background image fails to load. I've also added `color: #FEFEFE;` (white) because the existing font color for `#ug-header` was `#333` (black). This was tripping the WAVE tool into giving us another contrast issue - black text on red background.