### PR TITLE
(Migrate D7) Fix: Skip User 1 when importing/updating users [UG Migrate D7](fixes …

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_user.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_user.inc
@@ -7,6 +7,22 @@ class UGUser7Migration extends DrupalUser7Migration {
     	parent::__construct($arguments);
 
 	}
+
+	public function prepareRow($row){
+		if(parent::prepareRow($row)===FALSE){
+			return FALSE;
+		}
+
+		/*echo("<<<<<<<");
+		drush_print_r($row);
+		echo(">>>>>>>");*/
+
+		if($row->uid == '1'){
+			//Skip User 1
+			return FALSE;
+		}
+
+	}
 }
 
 class UGRole7Migration extends DrupalRole7Migration {

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_user.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_user.inc
@@ -18,7 +18,8 @@ class UGUser7Migration extends DrupalUser7Migration {
 		echo(">>>>>>>");*/
 
 		if($row->uid == '1'){
-			//Skip User 1
+			//Skip User 1 + preserve this row during rollback
+			$this->rollbackAction = MigrateMap::ROLLBACK_PRESERVE;
 			return FALSE;
 		}
 


### PR DESCRIPTION
Adds a check to see what user ID we're working with when importing users. If the user ID matches that of User 1, the row is skipped.

Fixes #338 
