### PR TITLE
New: Migrate image (img_assist) into Page body (UG Migrate D6)

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -41,6 +41,7 @@
     'source_page_category' => '',
     'source_page_keyword' => 'field_tags',
     'source_page_attachments' => 'upload',
+    'source_page_src_url' => '',
   );
   
   /* NEWS Settings */

--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -41,7 +41,7 @@
     'source_page_category' => '',
     'source_page_keyword' => 'field_tags',
     'source_page_attachments' => 'upload',
-    'source_page_src_url' => '',
+    'source_page_image_src_prefix' => '',
   );
   
   /* NEWS Settings */

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -320,7 +320,9 @@ class UGPage6Migration extends DrupalNode6Migration {
 		//Override default values with arguments if they exist
 		foreach ($page_arguments as $key => $value) {
 		    if(isset($this->arguments[$key])){
-		    	$page_arguments[$key] = $this->arguments[$key];
+		    	if($this->arguments[$key]!=''){
+			    	$page_arguments[$key] = $this->arguments[$key];
+			    }
 		    }
 		}
 
@@ -354,6 +356,60 @@ class UGPage6Migration extends DrupalNode6Migration {
 	    $this->addFieldMapping('field_page_attachments:language')
 	        ->defaultValue(LANGUAGE_NONE);
 	}
+
+  /**
+   * Implementation of Migration::prepareRow().
+   */
+  public function prepareRow($row) {
+    if (parent::prepareRow($row) === FALSE) {
+      return FALSE;
+    }
+    // image query
+    $pattern = strval($row->nid) . '.%';
+    $image = Database::getConnection('default', 'default')
+      ->select('file_managed', 'f')
+      ->fields('f', array('fid','uri'))
+      ->condition('filename', $pattern, 'LIKE')
+      ->execute()
+      ->fetchObject();
+
+    if ($image) {
+    	$src_url = '';
+    	if(isset($this->arguments['source_page_src_url'])){
+	    	$src_url = $this->arguments['source_page_src_url'];
+    	}
+
+      $row->body = $this->replaceImgAssist($row->body, $image, $src_url);
+    }
+  }
+
+
+  public function replaceImgAssist(&$body, &$image, &$src_url){
+
+  	$pattern = '/\[img_assist\|(.+?)]/';
+  	$pattern_desc = '/(?<=desc=)([\d\s\w\.\?\,]+?)(?=\|)/';
+
+	//$image_src = "/" . conf_path() . "/files/" . file_uri_target($image->uri);
+	$image_src = $src_url . "/" . conf_path() . "/files/" . file_uri_target($image->uri);
+	preg_match($pattern, $body, $matches);
+
+  /* @TO DO - allow for multiple images (UGImage6 only brings over a single feature image) */
+	$m = array_shift($matches);
+	//foreach($matches as $m){
+		if(strpos($m,'[img_assist') !== false){
+			preg_match($pattern_desc, $m, $desc_match);
+			$desc = array_shift($desc_match);
+			$replacement = '<img alt="' . $desc .'" class="img-responsive" src="'. $image_src .'" />';
+	  		$new_body = preg_replace($pattern, $replacement, $body);
+	  	}
+	//}
+
+  	if($new_body){
+	  	return $new_body;
+  	}
+
+  	return $body;
+  }
 }
 
 

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -374,23 +374,23 @@ class UGPage6Migration extends DrupalNode6Migration {
       ->fetchObject();
 
     if ($image) {
-    	$src_url = '';
-    	if(isset($this->arguments['source_page_src_url'])){
-	    	$src_url = $this->arguments['source_page_src_url'];
+    	$image_src_prefix = '';
+    	if(isset($this->arguments['source_page_image_src_prefix'])){
+	    	$image_src_prefix = $this->arguments['source_page_image_src_prefix'];
     	}
 
-      $row->body = $this->replaceImgAssist($row->body, $image, $src_url);
+      $row->body = $this->replaceImgAssist($row->body, $image, $image_src_prefix);
     }
   }
 
 
-  public function replaceImgAssist(&$body, &$image, &$src_url){
+  public function replaceImgAssist(&$body, &$image, &$image_src_prefix){
 
   	$pattern = '/\[img_assist\|(.+?)]/';
   	$pattern_desc = '/(?<=desc=)([\d\s\w\.\?\,]+?)(?=\|)/';
 
 	//$image_src = "/" . conf_path() . "/files/" . file_uri_target($image->uri);
-	$image_src = $src_url . "/" . conf_path() . "/files/" . file_uri_target($image->uri);
+	$image_src = $image_src_prefix . "/" . conf_path() . "/files/" . file_uri_target($image->uri);
 	preg_match($pattern, $body, $matches);
 
   /* @TO DO - allow for multiple images (UGImage6 only brings over a single feature image) */


### PR DESCRIPTION
Migrates a single image assist tag into the Page body field. Src url is likely going to be /sites/uoguelph.ca.sitename/files, however, if you find that the images can only be found at /sitename/uoguelph.ca.sitename/files, use ```source_page_image_src_prefix``` value to hold the ```/sitename``` prefix.

*Note:* Code still needs to be adapted so multiple image_assist tags are replaced by an <img> HTML tag (see https://github.com/ccswbs/hjckrrh/issues/373 for details).