### PR TITLE
Migrate featureditem d6

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -60,6 +60,20 @@
     'source_news_attachment' => 'upload',
   );
 
+  /* FEATURED ITEM Settings */
+  $featureditem_arguments = array(
+    'source_featureditem_node_type' => '',
+    'source_featureditem_term_category' => '',
+    'source_featureditem_term_keyword' => '',
+    'source_featureditem_body' => 'body',
+    'source_featureditem_summary' => 'body:summary',
+    'source_featureditem_format' => 'body:format',
+    'source_featureditem_link' => '',
+    'source_featureditem_image' => '',
+    'source_featureditem_category' => '',
+    'source_featureditem_keyword' => '',
+  );
+
   /* EVENT Settings */
   $event_arguments = array(
     'source_event_node_type' => '',

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -40,6 +40,12 @@ function ug_migrate_d6_migrate_api() {
 
   $event_multipart_arguments = array();
 
+  $featureditem_arguments = array(
+    'source_featureditem_node_type' => '',
+    'source_featureditem_term_category' => '',
+    'source_featureditem_term_keyword' => '',
+  );
+
   /* USER VARIABLES */
   $user_arguments = array(
     'role_mappings' => array(),
@@ -63,8 +69,8 @@ function ug_migrate_d6_migrate_api() {
   $menu_names = array('primary-links');
   $menu_link_arguments = array(
     'menu_migration' => 'UGMenu6',
-    'node_migrations' => array('UGPage6', 'UGNews6', 'UGEvent6'),
-    'term_migrations' => array('UGTerm6', 'UGPageCategory6', 'UGNewsCategory6', 'UGNewsKeyword6', 'UGEventCategory6', 'UGEventKeyword6'),
+    'node_migrations' => array('UGPage6', 'UGNews6', 'UGEvent6','UGFeaturedItem6'),
+    'term_migrations' => array('UGTerm6', 'UGPageCategory6', 'UGNewsCategory6', 'UGNewsKeyword6', 'UGEventCategory6', 'UGEventKeyword6','UGFeaturedItemCategory6', 'UGFeaturedItemKeyword6'),
   );
 
   $menu_arguments = $common_arguments + array(
@@ -181,6 +187,29 @@ function ug_migrate_d6_migrate_api() {
         'source_type' => $news_arguments['source_news_node_type'], 
         'destination_type' => 'news',
         'dependencies' => array('UGFile6','UGImage6'),
+      ),
+
+      /**** FEATURED ITEM migration ****/
+      'UGFeaturedItemKeyword6' => $common_arguments + array(
+        'description' => t('Migration of featured item keyword terms from Drupal 6'),
+        'class_name' => 'UGFeaturedItemKeyword6Migration',
+        'source_vocabulary' => $featureditem_arguments['source_featureditem_term_keyword'],
+        'destination_vocabulary' => 'tags',
+      ),
+
+      'UGFeaturedItemCategory6' => $common_arguments + array(
+        'description' => t('Migration of featured item category terms from Drupal 6'),
+        'class_name' => 'UGFeaturedItemCategory6Migration',
+        'source_vocabulary' => $featureditem_arguments['source_featureditem_term_category'],
+        'destination_vocabulary' => 'feature_category',
+      ),
+
+      'UGFeaturedItem6' => $node_arguments + $featureditem_arguments + array(
+        'description' => t('Migration of featured items from Drupal 6'),
+        'class_name' => 'UGFeaturedItem6Migration',
+        'source_type' => $featureditem_arguments['source_featureditem_node_type'], 
+        'destination_type' => 'feature',
+        'dependencies' => array('UGFile6', 'UGImage6'),
       ),
 
       /**** EVENT migration ****/

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -1,5 +1,91 @@
 <?php 
 
+
+class UGFeaturedItem6Migration extends DrupalNode6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+	    $this->destination = new MigrateDestinationNode('feature');
+
+		/* DEFAULT arguments */
+		$featureditem_arguments = array(
+			'source_featureditem_body' => 'body',
+			'source_featureditem_summary' => 'body:summary',
+			'source_featureditem_format' => 'body:format',
+			'source_featureditem_link' => '',
+			'source_featureditem_image' => 'fid',
+			'source_featureditem_category' => '',
+			'source_featureditem_keyword' => '',
+		);
+
+		//Override default values with arguments if they exist
+		foreach ($featureditem_arguments as $key => $value) {
+		    if(isset($this->arguments[$key])){
+		    	if($this->arguments[$key] != ''){
+			    	$featureditem_arguments[$key] = $this->arguments[$key];
+			    }
+		    }
+		}
+
+	    /* Featured Item Body */
+	    $this->addFieldMapping('field_feature_text', $featureditem_arguments['source_featureditem_body']);
+	    $this->addFieldMapping('field_feature_text:summary', $featureditem_arguments['source_featureditem_summary']);
+	    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+		    ->defaultValue('full_html');
+
+		/* Featured Item Category */
+		$this->addFieldMapping('field_feature_category', $featureditem_arguments['source_featureditem_category'])
+			->sourceMigration('UGFeaturedItemCategory6');
+		$this->addFieldMapping('field_feature_category:source_type')
+			->defaultValue('tid');
+
+		/* Featured Item Keyword */
+		$this->addFieldMapping('field_tags', $featureditem_arguments['source_featureditem_keyword'])
+			->sourceMigration('UGTerm6');
+		$this->addFieldMapping('field_tags:source_type')
+			->defaultValue('tid');
+
+		/* Featured Item Image */
+	    $this->addFieldMapping('field_feature_image', $featureditem_arguments['source_featureditem_image']);
+		$this->addFieldMapping('field_feature_image:file_class')
+		    ->defaultValue('MigrateFileFid');
+		$this->addFieldMapping('field_feature_image:preserve_files')
+		    ->defaultValue('TRUE');
+	    $this->addFieldMapping('field_feature_image:alt', $featureditem_arguments['source_featureditem_image'] . ':alt')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_feature_image:title', $featureditem_arguments['source_featureditem_image'] . ':title')
+	        ->defaultValue('');
+	    $this->addFieldMapping('field_feature_image:language')
+	        ->defaultValue(LANGUAGE_NONE);
+
+		/* Featured Item Link */
+	    $this->addFieldMapping('field_feature_link', $featureditem_arguments['source_featureditem_link']);
+	}
+
+  /**
+   * Implementation of Migration::prepareRow().
+   */
+  public function prepareRow($row) {
+    if (parent::prepareRow($row) === FALSE) {
+      return FALSE;
+    }
+    // image query
+    $pattern = strval($row->nid) . '.%';
+    $image = Database::getConnection('default', 'default')
+      ->select('file_managed', 'f')
+      ->fields('f', array('fid'))
+      ->condition('filename', $pattern, 'LIKE')
+      ->execute()
+      ->fetchObject();
+
+    if ($image) {
+      $row->fid = array($image->fid);
+	  //drush_print_r($row);
+    }
+  }
+
+}
+
+
 class UGEvent6Migration extends DrupalNode6Migration {
 	public function __construct($arguments) {
     	parent::__construct($arguments);
@@ -356,6 +442,20 @@ class UGPage6Migration extends DrupalNode6Migration {
 	}
 }
 
+
+class UGFeaturedItemCategory6Migration extends DrupalTerm6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+
+	}	
+}
+
+class UGFeaturedItemKeyword6Migration extends DrupalTerm6Migration {
+	public function __construct($arguments) {
+    	parent::__construct($arguments);
+
+	}	
+}
 
 class UGEventHeading6Migration extends DrupalTerm6Migration {
 	public function __construct($arguments) {


### PR DESCRIPTION


Fixes #355.

Migrates Featured Item, Featured Item category/keyword from Drupal 6 to Drupal 7. Depends on #344.

Testing Notes

    Recommend testing with data from CIO (eg. video)
    Compatible with Image Attach or Image Assist for featured item image

