### PR TITLE
Iss87 event listing summary

### DIFF
--- a/profiles/ug/CHANGELOG.txt
+++ b/profiles/ug/CHANGELOG.txt
@@ -8,4 +8,5 @@ Hjckrrh 7.2.0, 2016-05-17
 - Fix title of page feed when filter is "all".
 - Add Featured Item migration from Drupal 6 to Drupal 7.
 - Fix double escaping of special characters in profile names.
+- Use summary in event listing views (#87).
 

--- a/profiles/ug/modules/ug/ug_event/ug_event.features.field_base.inc
+++ b/profiles/ug/modules/ug/ug_event/ug_event.features.field_base.inc
@@ -10,7 +10,7 @@
 function ug_event_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'field_event_attachments'
+  // Exported field_base: 'field_event_attachments'.
   $field_bases['field_event_attachments'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -33,7 +33,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'file',
   );
 
-  // Exported field_base: 'field_event_body'
+  // Exported field_base: 'field_event_body'.
   $field_bases['field_event_body'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -52,7 +52,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'text_with_summary',
   );
 
-  // Exported field_base: 'field_event_category'
+  // Exported field_base: 'field_event_category'.
   $field_bases['field_event_category'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -79,7 +79,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
-  // Exported field_base: 'field_event_content'
+  // Exported field_base: 'field_event_content'.
   $field_bases['field_event_content'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -98,7 +98,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'text_long',
   );
 
-  // Exported field_base: 'field_event_date'
+  // Exported field_base: 'field_event_date'.
   $field_bases['field_event_date'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -128,7 +128,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'datetime',
   );
 
-  // Exported field_base: 'field_event_heading'
+  // Exported field_base: 'field_event_heading'.
   $field_bases['field_event_heading'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -154,7 +154,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
-  // Exported field_base: 'field_event_image'
+  // Exported field_base: 'field_event_image'.
   $field_bases['field_event_image'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -177,7 +177,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'image',
   );
 
-  // Exported field_base: 'field_event_image_caption'
+  // Exported field_base: 'field_event_image_caption'.
   $field_bases['field_event_image_caption'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -198,7 +198,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_event_link'
+  // Exported field_base: 'field_event_link'.
   $field_bases['field_event_link'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -227,7 +227,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'link_field',
   );
 
-  // Exported field_base: 'field_event_location'
+  // Exported field_base: 'field_event_location'.
   $field_bases['field_event_location'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -246,7 +246,7 @@ function ug_event_field_default_field_bases() {
     'type' => 'text_long',
   );
 
-  // Exported field_base: 'field_event_multipart'
+  // Exported field_base: 'field_event_multipart'.
   $field_bases['field_event_multipart'] = array(
     'active' => 1,
     'cardinality' => -1,

--- a/profiles/ug/modules/ug/ug_event/ug_event.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_event/ug_event.features.field_instance.inc
@@ -11,7 +11,7 @@ function ug_event_field_default_field_instances() {
   $field_instances = array();
 
   // Exported field_instance:
-  // 'field_collection_item-field_event_multipart-field_event_content'
+  // 'field_collection_item-field_event_multipart-field_event_content'.
   $field_instances['field_collection_item-field_event_multipart-field_event_content'] = array(
     'bundle' => 'field_event_multipart',
     'default_value' => NULL,
@@ -51,7 +51,7 @@ function ug_event_field_default_field_instances() {
   );
 
   // Exported field_instance:
-  // 'field_collection_item-field_event_multipart-field_event_heading'
+  // 'field_collection_item-field_event_multipart-field_event_heading'.
   $field_instances['field_collection_item-field_event_multipart-field_event_heading'] = array(
     'bundle' => 'field_event_multipart',
     'default_value' => NULL,
@@ -82,7 +82,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_attachments'
+  // Exported field_instance: 'node-event-field_event_attachments'.
   $field_instances['node-event-field_event_attachments'] = array(
     'bundle' => 'event',
     'deleted' => 0,
@@ -124,7 +124,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_body'
+  // Exported field_instance: 'node-event-field_event_body'.
   $field_instances['node-event-field_event_body'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -171,7 +171,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_category'
+  // Exported field_instance: 'node-event-field_event_category'.
   $field_instances['node-event-field_event_category'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -208,7 +208,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_date'
+  // Exported field_instance: 'node-event-field_event_date'.
   $field_instances['node-event-field_event_date'] = array(
     'bundle' => 'event',
     'deleted' => 0,
@@ -262,7 +262,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_image'
+  // Exported field_instance: 'node-event-field_event_image'.
   $field_instances['node-event-field_event_image'] = array(
     'bundle' => 'event',
     'deleted' => 0,
@@ -312,7 +312,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_image_caption'
+  // Exported field_instance: 'node-event-field_event_image_caption'.
   $field_instances['node-event-field_event_image_caption'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -352,7 +352,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_link'
+  // Exported field_instance: 'node-event-field_event_link'.
   $field_instances['node-event-field_event_link'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -414,7 +414,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_location'
+  // Exported field_instance: 'node-event-field_event_location'.
   $field_instances['node-event-field_event_location'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -459,7 +459,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_event_multipart'
+  // Exported field_instance: 'node-event-field_event_multipart'.
   $field_instances['node-event-field_event_multipart'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -502,7 +502,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-event-field_tags'
+  // Exported field_instance: 'node-event-field_tags'.
   $field_instances['node-event-field_tags'] = array(
     'bundle' => 'event',
     'default_value' => NULL,
@@ -542,7 +542,7 @@ function ug_event_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'taxonomy_term-event_heading-field_glyphicon'
+  // Exported field_instance: 'taxonomy_term-event_heading-field_glyphicon'.
   $field_instances['taxonomy_term-event_heading-field_glyphicon'] = array(
     'bundle' => 'event_heading',
     'default_value' => NULL,

--- a/profiles/ug/modules/ug/ug_event/ug_event.info
+++ b/profiles/ug/modules/ug/ug_event/ug_event.info
@@ -73,4 +73,3 @@ features[views_view][] = event_week_list
 features_exclude[dependencies][ctools] = ctools
 features_exclude[field_base][body] = body
 files[] = ug_event.test
-

--- a/profiles/ug/modules/ug/ug_event/ug_event.info
+++ b/profiles/ug/modules/ug/ug_event/ug_event.info
@@ -73,3 +73,4 @@ features[views_view][] = event_week_list
 features_exclude[dependencies][ctools] = ctools
 features_exclude[field_base][body] = body
 files[] = ug_event.test
+

--- a/profiles/ug/modules/ug/ug_event/ug_event.test
+++ b/profiles/ug/modules/ug/ug_event/ug_event.test
@@ -35,14 +35,6 @@ class UGEventTestCase extends DrupalWebTestCase {
       'events/week',
       'events/month',
       'events/archive',
-/*
-      'faq',
-      'features',
-      'news',
-      'pages',
-      'connect',
-      'tags'
-*/
     );
   }
 
@@ -55,6 +47,28 @@ class UGEventTestCase extends DrupalWebTestCase {
     /* Assert that 'More events' button is hidden. */
     $this->drupalGet('');
     $this->assertNoText($this->more_text);
+  }
+
+  /**
+   * Test event summary is used on listing pages.
+   */
+  function testSummary() {
+    /* Generate some random text. */
+    $body_text = $this->randomString();
+    $summary_text = $this->randomString();
+    /* Create a node with body and summary. */
+    $settings = array();
+    $settings['type'] = 'event';
+    $settings['field_event_body'][LANGUAGE_NONE][0]['value'] = $body_text;
+    $settings['field_event_body'][LANGUAGE_NONE][0]['summary'] = $summary_text;
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value'] = '2018-01-10 20:00:45';
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value2'] = '2018-01-10 22:30:45';
+    $node = $this->drupalCreateNode($settings);
+    /* Get events listing page. */
+    $this->drupalGet('events');
+    /* Should show summary, not body. */
+    $this->assertText($summary_text);
+    $this->assertNoText($body_text);
   }
 
 }

--- a/profiles/ug/modules/ug/ug_event/ug_event.test
+++ b/profiles/ug/modules/ug/ug_event/ug_event.test
@@ -54,19 +54,30 @@ class UGEventTestCase extends DrupalWebTestCase {
    */
   function testSummary() {
     /* Generate some random text. */
-    $body_text = $this->randomString();
-    $summary_text = $this->randomString();
+    $later = time() + 3600;
+    $date = date("Y-m-d H:i:s", $later);
+    $date2 = date("Y-m-d H:i:s", $later + 7200);
+    $body_text = $this->randomName();
+    $summary_text = $this->randomName();
     /* Create a node with body and summary. */
     $settings = array();
     $settings['type'] = 'event';
     $settings['field_event_body'][LANGUAGE_NONE][0]['value'] = $body_text;
     $settings['field_event_body'][LANGUAGE_NONE][0]['summary'] = $summary_text;
-    $settings['field_event_date'][LANGUAGE_NONE][0]['value'] = '2018-01-10 20:00:45';
-    $settings['field_event_date'][LANGUAGE_NONE][0]['value2'] = '2018-01-10 22:30:45';
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value'] = $date;
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value2'] = $date2;
     $node = $this->drupalCreateNode($settings);
     /* Get events listing page. */
     $this->drupalGet('events');
     /* Should show summary, not body. */
+    $this->assertText($summary_text);
+    $this->assertNoText($body_text);
+    /* Repeat for month list... */
+    $this->drupalGet('events/month');
+    $this->assertText($summary_text);
+    $this->assertNoText($body_text);
+    /* ... and for week list. */
+    $this->drupalGet('events/week');
     $this->assertText($summary_text);
     $this->assertNoText($body_text);
   }

--- a/profiles/ug/modules/ug/ug_event/ug_event.views_default.inc
+++ b/profiles/ug/modules/ug/ug_event/ug_event.views_default.inc
@@ -81,9 +81,10 @@ function ug_event_views_default_views() {
   $handler->display->display_options['fields']['field_event_body']['field'] = 'field_event_body';
   $handler->display->display_options['fields']['field_event_body']['label'] = '';
   $handler->display->display_options['fields']['field_event_body']['alter']['max_length'] = '255';
-  $handler->display->display_options['fields']['field_event_body']['alter']['trim'] = TRUE;
+  $handler->display->display_options['fields']['field_event_body']['alter']['strip_tags'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['alter']['html'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_event_body']['type'] = 'text_summary_or_trimmed';
   $handler->display->display_options['fields']['field_event_body']['settings'] = array(
     'trim_length' => '600',
   );
@@ -1147,10 +1148,14 @@ return false;';
   $handler->display->display_options['fields']['field_event_body']['field'] = 'field_event_body';
   $handler->display->display_options['fields']['field_event_body']['label'] = '';
   $handler->display->display_options['fields']['field_event_body']['alter']['max_length'] = '255';
-  $handler->display->display_options['fields']['field_event_body']['alter']['trim'] = TRUE;
+  $handler->display->display_options['fields']['field_event_body']['alter']['strip_tags'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['alter']['html'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_event_body']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_event_body']['type'] = 'text_summary_or_trimmed';
+  $handler->display->display_options['fields']['field_event_body']['settings'] = array(
+    'trim_length' => '600',
+  );
   /* Sort criterion: Content: Date -  start date (field_event_date) */
   $handler->display->display_options['sorts']['field_event_date_value']['id'] = 'field_event_date_value';
   $handler->display->display_options['sorts']['field_event_date_value']['table'] = 'field_data_field_event_date';
@@ -1378,10 +1383,14 @@ return false;';
   $handler->display->display_options['fields']['field_event_body']['field'] = 'field_event_body';
   $handler->display->display_options['fields']['field_event_body']['label'] = '';
   $handler->display->display_options['fields']['field_event_body']['alter']['max_length'] = '255';
-  $handler->display->display_options['fields']['field_event_body']['alter']['trim'] = TRUE;
+  $handler->display->display_options['fields']['field_event_body']['alter']['strip_tags'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['alter']['html'] = TRUE;
   $handler->display->display_options['fields']['field_event_body']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_event_body']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_event_body']['type'] = 'text_summary_or_trimmed';
+  $handler->display->display_options['fields']['field_event_body']['settings'] = array(
+    'trim_length' => '600',
+  );
   /* Sort criterion: Content: Date -  start date (field_event_date) */
   $handler->display->display_options['sorts']['field_event_date_value']['id'] = 'field_event_date_value';
   $handler->display->display_options['sorts']['field_event_date_value']['table'] = 'field_data_field_event_date';


### PR DESCRIPTION
Fixes issue #87.

Changes event listing views to use the body summary or trimmed value, instead of the default body value.
HTML is stripped from the summary to prevent layout problems.
