### PR TITLE
Update base.css - add bootstrap carousel overrides

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -553,4 +553,94 @@ p
   {
     word-wrap: break-word;
   }
+  
+/*---------------------
+Carousel Overrides
+---------------------**/
 
+.carousel-indicators {
+    all: initial;
+    display: table-cell;
+    text-align: center;
+}
+
+.carousel-indicators li {
+    all: initial;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+@media (max-width: 768px) {
+    .carousel-indicators li a {
+        font-size: 12px;
+        padding: 5px 10px;
+    }
+}
+
+.carousel-inner > .item > img {
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+}
+
+.carousel-table {
+    display: table;
+    margin: auto;
+}
+
+.carousel-table a.glyphicon {
+    padding: 6px;
+    top: -10px;
+    border: 1px solid #ddd;
+    border-radius: 50%;
+}
+
+.carousel-table a.glyphicon:hover,
+.carousel-table a.glyphicon:focus {
+    background-color: #eee;
+    text-decoration: none;
+}
+
+.carousel-table a.glyphicon-chevron-left {
+    margin-right: 0.75em;
+}
+
+.carousel-table a.glyphicon-chevron-right {
+    margin-left: 0.75em;
+}
+
+/* Hack for IE 11's lack of support for css all:initial */
+
+_:-ms-fullscreen, :root .carousel-indicators { 
+    position: static;
+    width: auto;
+    margin: 0;
+}
+
+_:-ms-fullscreen, :root .carousel-indicators li { 
+    width: auto;
+    height: auto;
+    text-indent: 0;
+    display: table-cell;
+}
+
+_:-ms-fullscreen, :root .carousel-table a.glyphicon {
+    top: -10px;
+}
+
+/* Hack for MS Edge's inadequate support of css all:initial ' */
+
+@supports (-ms-accelerator:true)  {
+    .carousel-indicators { 
+        position: static;
+        width: auto;
+        margin: 0;
+    }
+    .carousel-indicators li { 
+        width: auto;
+        height: auto;
+        text-indent: 0;
+        display: table-cell;
+    }
+    .carousel-table a.glyphicon {
+        top: -10px;
+    }
+}

--- a/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
+++ b/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
@@ -35,3 +35,21 @@ Dropdown Menus
 			});
 		}
 	)
+	
+	/*---------------------------------
+	Bootstrap carousel screenreader fix
+	--------------------------------**/
+	
+	jQuery(
+		// Remove "Current slide" text from old active slide and add it to new one
+		function markCurrentSlide() {
+			$(".carousel-indicators li p.sr-only").remove();
+			$(this).before("<p class='sr-only'>Current slide:</p>");
+		}
+	
+		// Add "Current slide" text to active slide on page load, then move it to new active slide on click
+		$(document).ready(function() {
+			$(".carousel-indicators li.active a").before("<p class='sr-only'>Current slide:</p>");
+			$(".carousel-indicators li a").click(markCurrentSlide);
+		});
+	)

--- a/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
+++ b/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
@@ -40,7 +40,7 @@ Dropdown Menus
 	Bootstrap carousel screenreader fix
 	--------------------------------**/
 	
-	jQuery(
+	jQuery(function($) {
 		// Remove "Current slide" text from old active slide and add it to new one
 		function markCurrentSlide() {
 			$(".carousel-indicators li p.sr-only").remove();
@@ -48,8 +48,6 @@ Dropdown Menus
 		}
 	
 		// Add "Current slide" text to active slide on page load, then move it to new active slide on click
-		$(document).ready(function() {
-			$(".carousel-indicators li.active a").before("<p class='sr-only'>Current slide:</p>");
-			$(".carousel-indicators li a").click(markCurrentSlide);
-		});
-	)
+		$(".carousel-indicators li.active a").before("<p class='sr-only'>Current slide:</p>");
+		$(".carousel-indicators li a").click(markCurrentSlide);
+	});


### PR DESCRIPTION
- Wrap slide navigation indicators in div carousel-table for better positioning
- Make indicators larger and keyboard-accessible, with media query to shrink them slightly for small screens
- Use existing pagination styling for the indicators 
- Move the previous and next slide icons so they bookend the indicators