### PR TITLE
Create rules-fix-fatal-error-features-revert-2186363-2.patch

### DIFF
--- a/patches/rules-fix-fatal-error-features-revert-2186363-2.patch
+++ b/patches/rules-fix-fatal-error-features-revert-2186363-2.patch
@@ -1,0 +1,36 @@
+diff --git a/includes/rules.plugins.inc b/includes/rules.plugins.inc
+index 90b306d..a41e3a4 100755
+--- a/includes/rules.plugins.inc
++++ b/includes/rules.plugins.inc
+@@ -489,6 +489,7 @@ class RulesReactionRule extends Rule implements RulesTriggerableInterface {
+   }
+ 
+   protected function exportChildren($key = 'ON') {
++    $export = array();
+     foreach ($this->events as $event_name) {
+       $export[$key][$event_name] = (array) $this->getEventSettings($event_name);
+     }
+@@ -498,14 +499,16 @@ class RulesReactionRule extends Rule implements RulesTriggerableInterface {
+   protected function importChildren($export, $key = 'ON') {
+     // Detect and support old-style exports: a numerically indexed array of
+     // event names.
+-    if (is_string(reset($export[$key])) && is_numeric(key($export[$key]))) {
+-      $this->events = $export[$key];
+-    }
+-    else {
+-      $this->events = array_keys($export[$key]);
+-      $this->eventSettings = array_filter($export[$key]);
++    if(isset($export[$key])){
++      if (is_string(reset($export[$key])) && is_numeric(key($export[$key]))) {
++        $this->events = $export[$key];
++      }
++      else {
++        $this->events = array_keys($export[$key]);
++        $this->eventSettings = array_filter($export[$key]);
++      }
++      parent::importChildren($export);
+     }
+-    parent::importChildren($export);
+   }
+ 
+   /**


### PR DESCRIPTION
couldn't run feature-update on a couple of features due to the following error:
Fatal error: Unsupported operand types in rules.plugins.inc
See https://www.drupal.org/node/2186363 for more details