### PR TITLE
Fix: Course Outlines detail page should hide field labels if no Term, Instructor

### DIFF
--- a/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
+++ b/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
@@ -103,5 +103,18 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
     $this->assertUrl($expected_path);
   }
 
+  /**
+  * Tests if the labels 'term' & 'instructor' are hidden when blank
+  */
+  function testHiddenLabels() {
+    $settings = array('type' => 'course_outline');
+    $name = $settings['field_course_name'][LANGUAGE_NONE][0]['value'] = $this->randomName();
+    $code = $settings['field_course_code'][LANGUAGE_NONE][0]['value'] = $this->randomName();
+    $node1 = $this->drupalCreateNode($settings);
+    $this->drupalGet('node/' . $node1->nid);
+  
+    $this->assertNoText(t('Term:'), 'The \'Term:\' text does not appear when field is blank');
+    $this->assertNoText(t('Instructor:'), 'The \'Instructor:\' text does not appear when field is blank');
+  }
 }
 


### PR DESCRIPTION
Fixes #494.