### PR TITLE
Fix issue606 - Hide button parent with display:none

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -1051,3 +1051,15 @@ function ug_theme_feed_icon($variables) {
   return l($image, $variables['url'], array('html' => TRUE, 'attributes' => array('class' => array('feed-icon', 'btn', 'btn-default'), 'title' => $text)));
 }
 
+/**
+* 
+*/
+function ug_theme_form_alter(array &$form, array &$form_state = array(), $form_id = NULL) {
+  bootstrap_form_alter($form, $form_state, $form_id);
+  if($form_id == 'search_form') {
+    unset($form['basic']['submit']);
+  } else if ($form_id == 'search_block_form') {
+    $classes = &$form['actions']['submit']['#attributes']['class'];
+    $form['actions']['#attributes']['class'][] = 'element-hidden';
+  }
+}


### PR DESCRIPTION
Fix issue #606.

Hid parent wrapper of problematic button using the class element-hidden which applies display:none. Bootstrap's hook_form_alter was overridden in the ug_theme to accomplish this.