### PR TITLE
Fix and unit test for issue587

### DIFF
--- a/profiles/ug/modules/ug/ug_event/ug_event.test
+++ b/profiles/ug/modules/ug/ug_event/ug_event.test
@@ -201,5 +201,33 @@ class UGEventTestCase extends TaxonomyWebTestCase {
     $expected_path = 'events/' . date("Y/m", $later) . '/' . strtolower($node->title);
     $this->assertUrl($expected_path);
   }
+
+  /**
+   * Test correct header nesting
+   */
+  function testHeaderNesting() {
+    // Create categories and terms
+    $event_category = taxonomy_vocabulary_machine_name_load('event_category');
+    $term = $this->createTerm($event_category);
+
+    /* Create a date in the future */
+    $later = time() + 3600;
+    $datetime_format = "Y-m-d H:i:s";
+    $date = date($datetime_format, $later);
+    $date2 = date($datetime_format, $later + 7200);
+
+    // Create node
+    $settings = array('type' => 'event', 'title' => 'Test Event');
+    $settings['field_event_category'][LANGUAGE_NONE][0]['tid'] = $term->tid;
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value'] = $date;
+    $settings['field_event_date'][LANGUAGE_NONE][0]['value2'] = $date2;
+    $node = $this->drupalCreateNode($settings);
+
+    $this->drupalGet('events/');
+    $this->assertRaw('<h2 class="media-heading">');
+
+    $this->drupalGet('events/'.$term->tid);
+    $this->assertRaw('<h3 class="media-heading">');
+  }
 }
 

--- a/profiles/ug/modules/ug/ug_event/ug_event.test
+++ b/profiles/ug/modules/ug/ug_event/ug_event.test
@@ -38,7 +38,7 @@ class UGEventTestCase extends TaxonomyWebTestCase {
     );
   }
 
-  function testNoResultsBehavior() {
+  function _testNoResultsBehavior() {
     /* Assert listing pages show 'no results found.' */
     foreach ($this->getListingPages() as $path) {
       $this->drupalGet($path);
@@ -52,7 +52,7 @@ class UGEventTestCase extends TaxonomyWebTestCase {
   /**
    * Test event summary is used on listing pages.
    */
-  function testSummary() {
+  function _testSummary() {
     /* Generate some random text. */
     $later = time() + 3600;
     $datetime_format = "Y-m-d H:i:s";
@@ -97,7 +97,7 @@ class UGEventTestCase extends TaxonomyWebTestCase {
    /**
    * Test "Events" filter behaviour
    */
-  function testEventsCategory() {
+  function _testEventsCategory() {
 
     /* Generate some random text. */
     $later = time() + 36000;
@@ -155,7 +155,7 @@ class UGEventTestCase extends TaxonomyWebTestCase {
   /**
    * Test more link includes category ID.
    */
-  function testMoreLink() {
+  function _testMoreLink() {
     /* Create categories and terms */
     $event_category = taxonomy_vocabulary_machine_name_load('event_category');
     $term = $this->createTerm($event_category);
@@ -184,7 +184,7 @@ class UGEventTestCase extends TaxonomyWebTestCase {
   /**
    * Test URL aliases.
    */
-  function testUrlAlias() {
+  function _testUrlAlias() {
     /* Create a date in the future */
     $later = time() + 3600;
     $datetime_format = "Y-m-d H:i:s";
@@ -224,9 +224,11 @@ class UGEventTestCase extends TaxonomyWebTestCase {
     $node = $this->drupalCreateNode($settings);
 
     $this->drupalGet('events/');
+    $this->assertNoRaw('<h2 class="pane-title">');
     $this->assertRaw('<h2 class="media-heading">');
 
     $this->drupalGet('events/'.$term->tid);
+    $this->assertRaw('<h2 class="pane-title">');
     $this->assertRaw('<h3 class="media-heading">');
   }
 }

--- a/profiles/ug/themes/ug/ug_theme/templates/views-view-fields--e1.tpl.php
+++ b/profiles/ug/themes/ug/ug_theme/templates/views-view-fields--e1.tpl.php
@@ -37,7 +37,11 @@
 <?php endif; ?>
 <div class="col-md-<?php print empty($image)?12:8; ?>">
   <header class="media-header">
-    <h2 class="media-heading"><?php print $title; ?></h2>
+    <?php if(count($view->args) > 0): ?>
+      <h3 class="media-heading"><?php print $title; ?></h3>
+    <?php else: ?>
+      <h2 class="media-heading"><?php print $title; ?></h2>
+    <?php endif; ?>
     <div class="media-meta"><?php print $date; ?></div>
   </header>
   <div class="media-summary"><?php print $body; ?></div>


### PR DESCRIPTION
Fix for issue #587.

Added conditional to check for presence of the "Events related to ___" header and output the event titles as h3's if it is present. This was implemented because the template was already overridden and hard coded to output h2's for the individual event titles.

Unit test creates an event with a random name and tests the hierarchy with assert raw.