### PR TITLE
Issue #548 - Fix exceptions in tests caused by print module

### DIFF
--- a/profiles/ug/modules/ug/ug_social/ug_social.features.inc
+++ b/profiles/ug/modules/ug/ug_social/ug_social.features.inc
@@ -46,7 +46,7 @@ function ug_social_node_info() {
  */
 function ug_social_install() {
   // Array of modules to be enabled
-  $modules = array('print', 'print_ui', 'print_pdf', 'print_tcpdf');
+  $modules = array('print', 'print_ui', 'print_pdf', 'print_pdf_tcpdf');
   // Enable specified modules and their dependencies
   module_enable($modules, TRUE);
 }
@@ -54,9 +54,9 @@ function ug_social_install() {
 /**
  * Implements hook_update().
  */
-function ug_social_update() {
+function ug_social_update_7100() {
   // Array of modules to be enabled
-  $modules = array('print', 'print_ui', 'print_pdf', 'print_tcpdf');
+  $modules = array('print', 'print_ui', 'print_pdf', 'print_pdf_tcpdf');
   // Enable specified modules and their dependencies
   module_enable($modules, TRUE);
 }

--- a/profiles/ug/modules/ug/ug_social/ug_social.features.inc
+++ b/profiles/ug/modules/ug/ug_social/ug_social.features.inc
@@ -40,3 +40,23 @@ function ug_social_node_info() {
   drupal_alter('node_info', $items);
   return $items;
 }
+
+/**
+ * Implements hook_install().
+ */
+function ug_social_install() {
+  // Array of modules to be enabled
+  $modules = array('print', 'print_ui', 'print_pdf', 'print_tcpdf');
+  // Enable specified modules and their dependencies
+  module_enable($modules, TRUE);
+}
+
+/**
+ * Implements hook_update().
+ */
+function ug_social_update() {
+  // Array of modules to be enabled
+  $modules = array('print', 'print_ui', 'print_pdf', 'print_tcpdf');
+  // Enable specified modules and their dependencies
+  module_enable($modules, TRUE);
+}

--- a/profiles/ug/ug.info
+++ b/profiles/ug/ug.info
@@ -21,7 +21,6 @@ dependencies[] = panels_bootstrap_layouts
 dependencies[] = panels_bootstrap_styles
 dependencies[] = path
 dependencies[] = pathauto
-dependencies[] = print
 dependencies[] = redirect
 dependencies[] = search
 dependencies[] = shortcut


### PR DESCRIPTION
Fix issue #548.

Removed 'print' as a dependency from ug.info and instead enabled it from hook_install in ug_social.features.inc.