### PR TITLE
Issue 548 - Add print permissions

### DIFF
--- a/profiles/ug/modules/ug/ug_social/ug_social.features.inc
+++ b/profiles/ug/modules/ug/ug_social/ug_social.features.inc
@@ -49,6 +49,13 @@ function ug_social_install() {
   $modules = array('print', 'print_ui', 'print_pdf', 'print_pdf_tcpdf');
   // Enable specified modules and their dependencies
   module_enable($modules, TRUE);
+  
+  // Add permissions
+  $permissions = array('access print');
+  foreach(array('anonymous user', 'authenticated user') as $role_name) {
+    $role = user_role_load_by_name($role_name);
+    user_role_grant_permissions($role->rid, $permissions);
+  }
 }
 
 /**
@@ -59,4 +66,11 @@ function ug_social_update_7100() {
   $modules = array('print', 'print_ui', 'print_pdf', 'print_pdf_tcpdf');
   // Enable specified modules and their dependencies
   module_enable($modules, TRUE);
+  
+  // Add permissions
+  $permissions = array('access print');
+  foreach(array('anonymous user', 'authenticated user') as $role_name) {
+    $role = user_role_load_by_name($role_name);
+    user_role_grant_permissions($role->rid, $permissions);
+  }
 }


### PR DESCRIPTION
Issue #548.

Adding permissions to the social feature causes exceptions in tests because it adds the print module to the .info file as a dependency. Enable print permissions from hook_install and hook_update instead.