### PR TITLE
Issue 485 - Override header color with link color

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -53,9 +53,15 @@ Base Styles
   /*---------------------
   Links
   ---------------------**/
-  a{
+  a {
       color: #2F70A9; 
       /* WCAG 2.0 AA on #EEEEEE, #F5F5F5, #FFFFFF */
+  }
+  
+  a.h1, a.h2, a.h3, a.h4, a.h5, a.h6 {
+    color:#2F70A9;
+    cursor:pointer;
+    border-bottom:1px solid;
   }
 
   /* default - no underline */
@@ -94,6 +100,12 @@ Base Styles
   /* hover/focus - links styled as buttons */
   p a.btn:focus, p a.btn:hover {
     border-bottom: 1px solid;
+  }
+  
+  /* hover/focus - links styled as headers */
+  a.h1:hover, a.h2:hover, a.h3:hover, a.h4:hover, a.h5:hover, a.h6:hover {
+    border-bottom:2px solid;
+    text-decoration:none;
   }
 
   nav li a, .navbar a, .menu a, a.active, .nav a, ul.list-inline li a {


### PR DESCRIPTION
Issue #485.

Links that are styled as headers (e.g. <a class="h2" href="#">Test</a>) will now appear blue with an underline. Previous behavior was for them to appear as normal headers with no indication they were clickable which is a failure according to the WCAG.

**Previous Behavior:**
![previous_link_color](https://cloud.githubusercontent.com/assets/25013998/23310783/aaba4ce4-fa81-11e6-8996-f305ab8be33a.png)

**Expected Behavior:**
![new_link_color](https://cloud.githubusercontent.com/assets/25013998/23310835/dc0247b6-fa81-11e6-8fbe-a5f3d30292fc.png)

Note that the HTML has been edited through the inspector in both instances to see the effect.