### PR TITLE
Issue 615 - Change font size and color for all-day events

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -127,12 +127,23 @@ Base Styles
   }
   
   /* Adjust calendar all-day link to have sufficient color contrast */
+  /* E8b */
   .calendar-calendar .month-view .full td.multi-day .inner div a {
     color:#000;
     font-size:11px;
   }
   
   .calendar-calendar .month-view .full td.multi-day div.monthview {
+    color:#000;
+  }
+  
+  /* E9b */
+  .calendar-calendar .week-view .full td.multi-day .inner div a {
+    color:#000;
+    font-size:11px;
+  }
+  
+  .calendar-calendar .week-view .full td.multi-day div.weekview {
     color:#000;
   }
 

--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -125,6 +125,16 @@ Base Styles
     text-decoration: none;
     border-bottom: 1px solid;
   }
+  
+  /* Adjust calendar all-day link to have sufficient color contrast */
+  .calendar-calendar .month-view .full td.multi-day .inner div a {
+    color:#000;
+    font-size:11px;
+  }
+  
+  .calendar-calendar .month-view .full td.multi-day div.monthview {
+    color:#000;
+  }
 
   /*---------------------
   Lists


### PR DESCRIPTION
Issue #615.

Changed font from default link color (#2F70A9) to black (#000000) which has a contrast ratio of 8.11 against the blue background of an all-day event (#74A5D7). Also changed the font size from "x-small" to "11px" as the next relative size up (small) was too large to look good.

The above was accomplished by overriding the calendar module's styles in our theme's base.css. Works for both E8b and E9b.

**Before/After:**
![calendar_before_after](https://cloud.githubusercontent.com/assets/25013998/23313300/255defa6-fa8b-11e6-8055-a5e1adf702bd.png)
