### PR TITLE
Iss659

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.info
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.info
@@ -5,6 +5,7 @@ package = UG
 version = 7.x-7.52
 project = ug_profile
 dependencies[] = auto_nodetitle
+dependencies[] = ds
 dependencies[] = ds_bootstrap_layouts
 dependencies[] = field_collection
 dependencies[] = field_group

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
@@ -229,8 +229,9 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['field_profile_office']['table'] = 'field_data_field_profile_office';
   $handler->display->display_options['fields']['field_profile_office']['field'] = 'field_profile_office';
   $handler->display->display_options['fields']['field_profile_office']['element_type'] = '0';
-  $handler->display->display_options['fields']['field_profile_office']['element_label_type'] = 'div';
+  $handler->display->display_options['fields']['field_profile_office']['element_label_type'] = 'strong';
   $handler->display->display_options['fields']['field_profile_office']['element_label_class'] = 'field-label';
+  $handler->display->display_options['fields']['field_profile_office']['hide_empty'] = TRUE;
   /* Field: Content: Last name */
   $handler->display->display_options['fields']['field_profile_lastname']['id'] = 'field_profile_lastname';
   $handler->display->display_options['fields']['field_profile_lastname']['table'] = 'field_data_field_profile_lastname';
@@ -243,8 +244,6 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['field_profile_name']['field'] = 'field_profile_name';
   $handler->display->display_options['fields']['field_profile_name']['label'] = '';
   $handler->display->display_options['fields']['field_profile_name']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_profile_office']['element_label_type'] = 'strong';
-  $handler->display->display_options['fields']['field_profile_office']['hide_empty'] = TRUE;
   $handler->display->display_options['allow']['use_pager'] = 'use_pager';
   $handler->display->display_options['allow']['items_per_page'] = 'items_per_page';
   $handler->display->display_options['allow']['offset'] = 0;
@@ -757,11 +756,10 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['field_profile_align_names']['exclude'] = TRUE;
   $handler->display->display_options['fields']['field_profile_align_names']['element_type'] = '0';
   $handler->display->display_options['fields']['field_profile_align_names']['element_label_colon'] = FALSE;
-  /* Sort criterion: Content: Post date */
-  $handler->display->display_options['sorts']['created']['id'] = 'created';
-  $handler->display->display_options['sorts']['created']['table'] = 'node';
-  $handler->display->display_options['sorts']['created']['field'] = 'created';
-  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Sort criterion: Content: Last name (field_profile_lastname) */
+  $handler->display->display_options['sorts']['field_profile_lastname_value']['id'] = 'field_profile_lastname_value';
+  $handler->display->display_options['sorts']['field_profile_lastname_value']['table'] = 'field_data_field_profile_lastname';
+  $handler->display->display_options['sorts']['field_profile_lastname_value']['field'] = 'field_profile_lastname_value';
   /* Contextual filter: Content: Has taxonomy term ID */
   $handler->display->display_options['arguments']['tid']['id'] = 'tid';
   $handler->display->display_options['arguments']['tid']['table'] = 'taxonomy_index';
@@ -837,7 +835,7 @@ function ug_profile_views_default_views() {
   /* Display: Content pane */
   $handler = $view->new_display('panel_pane', 'Content pane', 'panel_pane_1');
   $handler->display->display_options['allow']['use_pager'] = 0;
-  $handler->display->display_options['allow']['items_per_page'] = 0;
+  $handler->display->display_options['allow']['items_per_page'] = 'items_per_page';
   $handler->display->display_options['allow']['offset'] = 0;
   $handler->display->display_options['allow']['link_to_view'] = 0;
   $handler->display->display_options['allow']['more_link'] = 0;

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
@@ -844,6 +844,16 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['allow']['title_override'] = 'title_override';
   $handler->display->display_options['allow']['exposed_form'] = 0;
   $handler->display->display_options['allow']['fields_override'] = 'fields_override';
+  $handler->display->display_options['argument_input'] = array(
+    'tid' => array(
+      'type' => 'panel',
+      'context' => 'entity:field_collection_item.archived',
+      'context_optional' => 0,
+      'panel' => '0',
+      'fixed' => '',
+      'label' => 'Content: Has taxonomy term ID',
+    ),
+  );
   $handler->display->display_options['inherit_panels_path'] = '1';
   $export['pp6'] = $view;
 


### PR DESCRIPTION
Fixes issue #657 , Fixes issue #658 , Fixes issue #659  

# Fix
## Issue 657
Under the PP6 view, Argument input, changed Content: Has taxonomy term ID source from `No Argument` to `From panel argument`.

## Issue 658
Under the PP6 view, Allow settings, added `Items per per page` to the list.

## Issue 659
Under the PP6 view, Sort Criteria, removed the `Content: Post date` sort criteria and added the `Content: Last name` sort criteria.

# Testing
_This is the test procedure I followed when testing this branch._

## Manual Testing
  1. Install site from the `iss659` branch on the hjckrrh repo
  2. Go to taxonomy
  3. Create some tags
  4. Create some Profile catagories
  5. Create some profiles
  6. Go to `site/people`
  7. Delete the `PP1` view
  8. Add the `PP6` view
  9. When adding the view, ensure that the option to select the number of items listed is available
  10. Ensure that the profiles are listed in alphabetical order by last name
  11. Go to `site/people/<term ID>`
  12. Ensure that the title changes to the name of the term 

## Automated Testing

### Procedure
  1. Install site from the `iss659` branch on the hjckrrh repo
  2. Run all the UG tests in Simpletest

## Expected Results
All of the UG tests should pass without errors or exceptions.