### PR TITLE
Iss628 profilelinks

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_base.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_base.inc
@@ -674,7 +674,7 @@ function ug_profile_field_default_field_bases() {
   // Exported field_base: 'field_profile_website'.
   $field_bases['field_profile_website'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_profile_website',

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_instance.inc
@@ -1067,7 +1067,7 @@ function ug_profile_field_default_field_instances() {
     ),
     'entity_type' => 'node',
     'field_name' => 'field_profile_website',
-    'label' => 'Website link',
+    'label' => 'Website links',
     'required' => 0,
     'settings' => array(
       'absolute_url' => 1,
@@ -1173,7 +1173,7 @@ function ug_profile_field_default_field_instances() {
   t('Sub-unit');
   t('Summary');
   t('Unit');
-  t('Website link');
+  t('Website links');
 
   return $field_instances;
 }

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.test
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.test
@@ -141,6 +141,43 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
     // Test office present
     $this->assertText("Office:");
   }
+
+  /**
+   * Test multiple website links 
+   */
+  function testMultipleWebsiteLinks() {
+    $websites_label = "Website links";
+    
+    /* Generate data */
+    $name = $this->randomName();
+    $lastname = $this->randomName();
+    $websites = array(
+      array('title' => $this->randomName(), 'url' => '<front>', 'attributes' => ''),
+      array('title' => $this->randomName(), 'url' => 'people/', 'attributes' => ''),
+    );
+
+    /* Create a node with multiple website links */
+    $settings = array('type' => 'profile');
+    $settings['field_profile_name'][LANGUAGE_NONE][0]['value'] = $name;
+    $settings['field_profile_lastname'][LANGUAGE_NONE][0]['value'] = $lastname;
+
+    foreach ($websites as $key => $site) {
+      $settings['field_profile_website'][LANGUAGE_NONE][$key]['title'] = $site['title'];
+      $settings['field_profile_website'][LANGUAGE_NONE][$key]['url'] = $site['url'];
+      $settings['field_profile_website'][LANGUAGE_NONE][$key]['attributes'] = $site['attributes'];
+    }
+
+    $node = $this->drupalCreateNode($settings);
+    $this->drupalGet('node/'.$node->nid);
+
+    /* Assert website links label */
+    $this->assertText($websites_label);
+
+    /* Assert multiple websites */
+    foreach ($websites as $key => $site) {
+      $this->assertLink($site['title']);
+    }
+  }
   
   /**
    * Test Last Name Search


### PR DESCRIPTION
Fixes #628 

Updated People Profile so that multiple website links can be associated with one profile.
Label has been updated from "Website link" to "Website links".
Test creates a profile node with multiple website links, goes to profile page, checks for "Website links" label and confirms that both links exist on the profile page.

# Testers
- Recommend adding multiple website links to a profile to check behaviour
- Recommend running UG Profile tests on Simpletest