### PR TITLE
Issue 662 - Change E3 filter from start date to end date

### DIFF
--- a/profiles/ug/modules/ug/ug_event/ug_event.views_default.inc
+++ b/profiles/ug/modules/ug/ug_event/ug_event.views_default.inc
@@ -506,12 +506,12 @@ return false;';
   $handler->display->display_options['filters']['type']['value'] = array(
     'event' => 'event',
   );
-  /* Filter criterion: Content: Date -  start date (field_event_date) */
-  $handler->display->display_options['filters']['field_event_date_value']['id'] = 'field_event_date_value';
-  $handler->display->display_options['filters']['field_event_date_value']['table'] = 'field_data_field_event_date';
-  $handler->display->display_options['filters']['field_event_date_value']['field'] = 'field_event_date_value';
-  $handler->display->display_options['filters']['field_event_date_value']['operator'] = '>=';
-  $handler->display->display_options['filters']['field_event_date_value']['default_date'] = 'now';
+  /* Filter criterion: Content: Date - end date (field_event_date:value2) */
+  $handler->display->display_options['filters']['field_event_date_value2']['id'] = 'field_event_date_value2';
+  $handler->display->display_options['filters']['field_event_date_value2']['table'] = 'field_data_field_event_date';
+  $handler->display->display_options['filters']['field_event_date_value2']['field'] = 'field_event_date_value2';
+  $handler->display->display_options['filters']['field_event_date_value2']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_event_date_value2']['default_date'] = 'now';
 
   /* Display: Content pane */
   $handler = $view->new_display('panel_pane', 'Content pane', 'panel_pane_1');


### PR DESCRIPTION
Fixes #662.

Applied the same fix to E3 as to #593.

## Test Procedure
1. Create test event with start date in -1 day and end date in +1 day
2. Ensure test event shows up in `/events` under Upcoming Events
3. Ensure test event shows up in E3
4. Run UG Event automated tests