### PR TITLE
Add snapchat (UG Social)[fixes #528]

### DIFF
--- a/profiles/ug/modules/ug/ug_social/ug_social.features.field_base.inc
+++ b/profiles/ug/modules/ug/ug_social/ug_social.features.field_base.inc
@@ -72,6 +72,9 @@ function ug_social_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_social_network',
+    'field_permissions' => array(
+      'type' => 0,
+    ),
     'indexes' => array(
       'value' => array(
         0 => 'value',
@@ -93,6 +96,7 @@ function ug_social_field_default_field_bases() {
         'flickr' => 'Flickr',
         'google-plus' => 'GooglePlus',
         'rss' => 'RSS',
+        'snapchat' => 'Snapchat',
       ),
       'allowed_values_function' => '',
     ),


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1927902/24811817/adc293bc-1b95-11e7-9d52-2af23b3c7e94.png)

Adds snapchat as an option under Social media network for UG Social. Because the icon is from a newer version of the Font Awesome library, the icon is not automatically included as part of the Font Awesome module that we have available.

For specific sites that want snapchat, to get the icon to show, you need to go under Configuration / Performance and ensure "Use CDN version of FontAwesome." is checked.

# Testing Method
1. Go under Configuration / Performance and ensure "Use CDN version of FontAwesome." is checked.
2. Create a social media item and fill in any necessary information
3. Select Snapchat as the Social media network
4. Save the social media item
5. See if the icon shows and functions on the Follow Us (Icons + Text) viewpane and the Follow Us (Icons Only) viewpane.

# Things to Keep in Mind

----

**Note:** Going forward, we may want to consider overwriting the Font Awesome library that comes local with the Drupal Font Awesome module with the most recent version of Font Awesome. We can do this by adding the following lines to the make file, re-running the makefile and committing the new library of Font Awesome that was downloaded:

```
libraries[font_awesome][download][type] = "git"
libraries[font_awesome][download][url] = "https://github.com/FortAwesome/Font-Awesome.git"
libraries[font_awesome][directory_name] = "fontawesome"
libraries[font_awesome][destination] = "libraries"
```

Since that decision is a bit larger in scope than this issue, I ended up going with the CDN option since only two sites have asked for SnapChat. This means we can easily enable the CDN version on those sites while we determine how to deal with the larger question of whether we go with Font Awesome CDN or keep updating the local copy (under sites/all/libraries) with more recent versions.

--

**Another thing to keep in mind:** I saw the following error when using the Social Media Follow us view panes. At first I thought the error was related to the Snapchat addition, but after doing a fresh install on my local machine, I saw it was occurring before snapchat was added. Based on the error, I have an inkling it may have to do with the version of PHP (5.6.10) I'm running on this older machine. Since we're running newer versions of PHP on the server, I think that's the reason I haven't been seeing it elsewhere. In any case, keep it in mind and if you see it occurring on an environment running newer versions of php, please create a separate issue to look into it.

![social-icons-error-1](https://cloud.githubusercontent.com/assets/1927902/24763723/39e04082-1ac0-11e7-8f6d-0e6fe0ba7f8e.png)
![social-icons-error-2](https://cloud.githubusercontent.com/assets/1927902/24763722/39d8756e-1ac0-11e7-9b3b-7f506d9cb86c.png)