### PR TITLE
Iss539 migrate format

### DIFF
--- a/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
+++ b/profiles/ug/modules/ug/ug_migrate_d6/migrate_settings_d6.php
@@ -145,6 +145,19 @@ $destination_sitestub = '';
     'source_term_keyword' => 'tags',
   );
 
+/**************************
+*  FORMAT Settings
+*
+*  Usage: Set override_format to TRUE to override all available textfield formats with default_format
+*    If override_format is set to FALSE, default_format is the fallback format for any textfields
+*    without a mapped source format
+**************************/
+
+  $format_arguments = array(
+    'default_format' => 'full_html',
+    'override_format' => FALSE,
+  );
+
 
 /* ----
 *

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6.migrate.inc
@@ -74,6 +74,8 @@ function ug_migrate_d6_migrate_api() {
   $node_arguments = $common_arguments + array(
     'user_migration' => 'UGUser6',
     'default_uid' => 1,
+    'default_format' => 'full_html',
+    'override_format' => FALSE,
   );
 
   $page_arguments = array(
@@ -179,6 +181,15 @@ function ug_migrate_d6_migrate_api() {
 
   if (file_exists($migrate_settings_override)){
     include $migrate_settings_override;
+  }
+
+  // Configure format settings
+  if(isset($format_arguments['default_format'])){
+    $node_arguments['default_format'] = $format_arguments['default_format'];
+  }
+
+  if(isset($format_arguments['override_format'])){
+    $node_arguments['override_format'] = $format_arguments['override_format'];
   }
 
   $api = array(

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_banner.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_banner.inc
@@ -54,25 +54,35 @@ class UGBanner6Migration extends UGDrupalNode6Migration {
 		$this->addFieldMapping('field_banner_headline', $banner_arguments['source_banner_headline']);			
 
 		// Banner Headline Format
-		if($banner_arguments['source_banner_headline'] == 'body'){
-			$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_headline:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_headline'] == 'body'){
+				$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		// Banner Text
 		$this->addFieldMapping('field_banner_text', $banner_arguments['source_banner_text']);
 		// Banner Text Format
-		if($banner_arguments['source_banner_text'] == 'body'){
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_text'] == 'body'){
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		// Banner Category

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_course.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_course.inc
@@ -84,13 +84,18 @@
 		    $this->addFieldMapping('field_course_body:summary', $course_arguments['source_course_summary']);
 
 			// Course Outline Body Format
-			if($course_arguments['source_course_body'] == 'body'){
-			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-				    ->defaultValue('full_html');
+			if($this->arguments['override_format'] == TRUE){
+				$this->addFieldMapping('field_course_body:format')
+					->defaultValue($this->arguments['default_format']);
 			}else{
-			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-				    ->callbacks(array($this, 'mapFormat'))
-				    ->defaultValue('full_html');
+				if($course_arguments['source_course_body'] == 'body'){
+				    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+					    ->defaultValue($this->arguments['default_format']);
+				}else{
+				    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+					    ->callbacks(array($this, 'mapFormat'))
+					    ->defaultValue($this->arguments['default_format']);
+				}
 			}
 
 			// Course Outline CATEGORY 

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_node.inc
@@ -277,13 +277,18 @@ class UGFeaturedItem6Migration extends UGDrupalNode6Migration {
 	    $this->addFieldMapping('field_feature_text:summary', $featureditem_arguments['source_featureditem_summary']);
 
 		// Featured Item Body Format
-		if($featureditem_arguments['source_featureditem_body'] == 'body'){
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_feature_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($featureditem_arguments['source_featureditem_body'] == 'body'){
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Featured Item Category */
@@ -373,13 +378,18 @@ class UGEvent6Migration extends UGDrupalNode6Migration {
 	    $this->addFieldMapping( 'field_event_body:summary', $event_arguments['source_event_summary']);
 
 		// Event Body Format
-		if($event_arguments['source_event_body'] == 'body'){
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_event_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($event_arguments['source_event_body'] == 'body'){
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Event Category */
@@ -572,13 +582,18 @@ class UGNews6Migration extends UGDrupalNode6Migration {
 	    $this->addFieldMapping( 'field_news_body:summary', $news_arguments['source_news_summary']);
 
 		// News Body Format
-		if($news_arguments['source_news_body'] == 'body'){
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_news_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($news_arguments['source_news_body'] == 'body'){
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* News Category */
@@ -680,13 +695,18 @@ class UGPage6Migration extends UGDrupalNode6Migration {
 	    $this->addFieldMapping('field_page_body:summary', $page_arguments['source_page_summary']);
 
 		// Page Body Format
-		if($page_arguments['source_page_body'] == 'body'){
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_page_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($page_arguments['source_page_body'] == 'body'){
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Page Category */
@@ -762,13 +782,18 @@ class UGFAQ6Migration extends UGDrupalNode6Migration {
 	    $this->addFieldMapping('field_faq_answer', $faq_arguments['source_faq_answer']);
 
 		// FAQ Answer Format
-		if($faq_arguments['source_faq_answer'] == 'body'){
-			$this->addFieldMapping('field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_faq_answer:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($faq_arguments['source_faq_answer'] == 'body'){
+				$this->addFieldMapping('field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* FAQ Category */

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_profile.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_profile.inc
@@ -120,13 +120,18 @@ class UGProfile6Migration extends UGDrupalNode6Migration {
 		$this->addFieldMapping('field_profile_summary', $profile_arguments['source_profile_summary']);
 
 		// Profile Summary Format
-		if($profile_arguments['source_profile_summary'] == 'body'){
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_profile_summary:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($profile_arguments['source_profile_summary'] == 'body'){
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Profile Category */

--- a/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_update.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d6/ug_migrate_d6_update.inc
@@ -470,13 +470,18 @@ class UGUpdatePage6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_page_body:summary', $page_arguments['source_page_summary']);
 
 		// Page Body Format
-		if($page_arguments['source_page_body'] == 'body'){
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_page_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($page_arguments['source_page_body'] == 'body'){
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -536,13 +541,18 @@ class UGUpdateNews6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_news_body:summary', $news_arguments['source_news_summary']);
 
 		// News Body Format
-		if($news_arguments['source_news_body'] == 'body'){
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_news_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($news_arguments['source_news_body'] == 'body'){
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -599,13 +609,18 @@ class UGUpdateEvent6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_event_body:summary', $event_arguments['source_event_summary']);
 
 		// Event Body Format
-		if($event_arguments['source_event_body'] == 'body'){
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_event_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($event_arguments['source_event_body'] == 'body'){
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -661,13 +676,18 @@ class UGUpdateFAQ6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_faq_answer', $faq_arguments['source_faq_answer']);
 
 		// FAQ Answer Format
-		if($faq_arguments['source_faq_answer'] == 'body'){
-			$this->addFieldMapping('field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_faq_answer:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($faq_arguments['source_faq_answer'] == 'body'){
+				$this->addFieldMapping('field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -724,13 +744,18 @@ class UGUpdateFeaturedItem6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_feature_text:summary', $featureditem_arguments['source_featureditem_summary']);
 
 		// Featured Item Body Format
-		if($featureditem_arguments['source_featureditem_body'] == 'body'){
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_feature_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($featureditem_arguments['source_featureditem_body'] == 'body'){
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -796,13 +821,18 @@ class UGUpdateProfile6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_profile_summary', $profile_arguments['source_profile_summary']);
 
 		// Profile Summary Format
-		if($profile_arguments['source_profile_summary'] == 'body'){
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_profile_summary:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($profile_arguments['source_profile_summary'] == 'body'){
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -858,13 +888,18 @@ class UGUpdateBanner6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_banner_text', $banner_arguments['source_banner_text']);
 
 		// Banner Text Format
-		if($banner_arguments['source_banner_text'] == 'body'){
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_text'] == 'body'){
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
     }
@@ -937,13 +972,18 @@ class UGUpdateCourseOutline6Migration extends UGUpdate6Migration {
 	    $this->addFieldMapping('field_course_body:summary', $course_arguments['source_course_summary']);
 
 		// Course Outline Body Format
-		if($course_arguments['source_course_body'] == 'body'){
-		    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_course_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($course_arguments['source_course_body'] == 'body'){
+			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 	}
 }

--- a/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
+++ b/profiles/ug/modules/ug/ug_migrate_d7/migrate_settings_d7.php
@@ -129,6 +129,19 @@ SITE CONFIGURATION VARIABLES
     'source_term_keyword' => 'tags',
   );
 
+/**************************
+*  FORMAT Settings
+*
+*  Usage: Set override_format to TRUE to override all available textfield formats with default_format
+*    If override_format is set to FALSE, default_format is the fallback format for any textfields
+*    without a mapped source format
+**************************/
+
+  $format_arguments = array(
+    'default_format' => 'full_html',
+    'override_format' => FALSE,
+  );
+
 
 
 /* ----

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7.migrate.inc
@@ -58,7 +58,6 @@ function ug_migrate_d7_migrate_api() {
     'UGBookKeyword7',
   );
 
-
   /* UPDATE VARIABLES */
   $update_arguments = array(
     'update_nodelinks' => FALSE,
@@ -76,6 +75,8 @@ function ug_migrate_d7_migrate_api() {
   $node_arguments = $common_arguments + array(
     'user_migration' => 'UGUser7',
     'default_uid' => 1,
+    'default_format' => 'full_html',
+    'override_format' => FALSE,
   );
 
   $page_arguments = array(
@@ -183,6 +184,15 @@ function ug_migrate_d7_migrate_api() {
 
   if (file_exists($migrate_settings_override)){
     include $migrate_settings_override;
+  }
+
+  // Configure format settings
+  if(isset($format_arguments['default_format'])){
+    $node_arguments['default_format'] = $format_arguments['default_format'];
+  }
+
+  if(isset($format_arguments['override_format'])){
+    $node_arguments['override_format'] = $format_arguments['override_format'];
   }
 
   $api = array(

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_banner.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_banner.inc
@@ -54,25 +54,35 @@ class UGBanner7Migration extends UGDrupalNode7Migration {
 		$this->addFieldMapping('field_banner_headline', $banner_arguments['source_banner_headline']);			
 
 		// Banner Headline Format
-		if($banner_arguments['source_banner_headline'] == 'body'){
-			$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_headline:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_headline'] == 'body'){
+				$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_headline:format', $banner_arguments['source_banner_headline_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		// Banner Text
 		$this->addFieldMapping('field_banner_text', $banner_arguments['source_banner_text']);
 		// Banner Text Format
-		if($banner_arguments['source_banner_text'] == 'body'){
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_text'] == 'body'){
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		// Banner Category

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_book.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_book.inc
@@ -81,13 +81,18 @@ class UGBook7Migration extends DrupalNode7Migration {
     $this->addFieldMapping('body:summary', $book_arguments['source_book_summary']);
 
     // Map Body Format
-    if($book_arguments['source_book_body'] == 'body'){
-        $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
-          ->defaultValue('full_html');
+    if($this->arguments['override_format'] == TRUE){
+      $this->addFieldMapping('body:format')
+        ->defaultValue($this->arguments['default_format']);
     }else{
-        $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
-          ->callbacks(array($this, 'mapFormat'))
-          ->defaultValue('full_html');
+      if($book_arguments['source_book_body'] == 'body'){
+          $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
+            ->defaultValue($this->arguments['default_format']);
+      }else{
+          $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
+            ->callbacks(array($this, 'mapFormat'))
+            ->defaultValue($this->arguments['default_format']);
+      }
     }
 
     // Map Book Category
@@ -296,13 +301,18 @@ class UGUpdateBook7Migration extends UGUpdate7Migration {
       $this->addFieldMapping('body:summary', $book_arguments['source_book_summary']);
 
       // Map Body Format
-      if($book_arguments['source_book_body'] == 'body'){
-          $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
-            ->defaultValue('full_html');
+      if($this->arguments['override_format'] == TRUE){
+        $this->addFieldMapping('body:format')
+          ->defaultValue($this->arguments['default_format']);
       }else{
-          $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
-            ->callbacks(array($this, 'mapFormat'))
-            ->defaultValue('full_html');
+        if($book_arguments['source_book_body'] == 'body'){
+            $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
+              ->defaultValue($this->arguments['default_format']);
+        }else{
+            $this->addFieldMapping('body:format', $book_arguments['source_book_format'])
+              ->callbacks(array($this, 'mapFormat'))
+              ->defaultValue($this->arguments['default_format']);
+        }
       }
   }
 }

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_course.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_course.inc
@@ -82,13 +82,18 @@
 		    $this->addFieldMapping('field_course_body:summary', $course_arguments['source_course_summary']);
 
 			// Course Outline Body Format
-			if($course_arguments['source_course_body'] == 'body'){
-			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-				    ->defaultValue('full_html');
+			if($this->arguments['override_format'] == TRUE){
+				$this->addFieldMapping('field_course_body:format')
+					->defaultValue($this->arguments['default_format']);
 			}else{
-			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-				    ->callbacks(array($this, 'mapFormat'))
-				    ->defaultValue('full_html');
+				if($course_arguments['source_course_body'] == 'body'){
+				    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+					    ->defaultValue($this->arguments['default_format']);
+				}else{
+				    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+					    ->callbacks(array($this, 'mapFormat'))
+					    ->defaultValue($this->arguments['default_format']);
+				}
 			}
 
 			// Course Outline CATEGORY 

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_node.inc
@@ -133,13 +133,18 @@ class UGFeaturedItem7Migration extends UGDrupalNode7Migration {
 	    $this->addFieldMapping('field_feature_text:summary', $featureditem_arguments['source_featureditem_summary']);
 
 		// Featured Item Body Format
-		if($featureditem_arguments['source_featureditem_body'] == 'body'){
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_feature_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($featureditem_arguments['source_featureditem_body'] == 'body'){
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Featured Item Category */
@@ -244,13 +249,18 @@ class UGEvent7Migration extends UGDrupalNode7Migration {
 	    $this->addFieldMapping('field_event_body:summary', $event_arguments['source_event_summary']);
 
 		// Event Body Format
-		if($event_arguments['source_event_body'] == 'body'){
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_event_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($event_arguments['source_event_body'] == 'body'){
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Event Category */
@@ -457,13 +467,18 @@ class UGNews7Migration extends UGDrupalNode7Migration {
 	    $this->addFieldMapping('field_news_body:summary', $news_arguments['source_news_summary']);
 
 		// News Body Format
-		if($news_arguments['source_news_body'] == 'body'){
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_news_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($news_arguments['source_news_body'] == 'body'){
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* News Category */
@@ -561,13 +576,18 @@ class UGPage7Migration extends UGDrupalNode7Migration {
 	    $this->addFieldMapping('field_page_body:summary', $page_arguments['source_page_summary']);
 
 		// Page Body Format
-		if($page_arguments['source_page_body'] == 'body'){
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_page_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($page_arguments['source_page_body'] == 'body'){
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Page Category */
@@ -641,13 +661,18 @@ class UGFAQ7Migration extends UGDrupalNode7Migration {
 	    $this->addFieldMapping('field_faq_answer', $faq_arguments['source_faq_answer']);
 
 		// FAQ Answer Format
-		if($faq_arguments['source_faq_answer'] == 'body'){
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_faq_answer:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($faq_arguments['source_faq_answer'] == 'body'){
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* FAQ Category */
@@ -917,13 +942,18 @@ class UGProfile7Migration extends UGDrupalNode7Migration {
 		$this->addFieldMapping('field_profile_summary', $profile_arguments['source_profile_summary']);
 
 		// Profile Summary Format
-		if($profile_arguments['source_profile_summary'] == 'body'){
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_profile_summary:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($profile_arguments['source_profile_summary'] == 'body'){
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
 		/* Profile Category */

--- a/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_update.inc
+++ b/profiles/ug/modules/ug/ug_migrate_d7/ug_migrate_d7_update.inc
@@ -317,13 +317,18 @@ class UGUpdatePage7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_page_body:summary', $page_arguments['source_page_summary']);
 
 		// Page Body Format
-		if($page_arguments['source_page_body'] == 'body'){
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_page_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($page_arguments['source_page_body'] == 'body'){
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_page_body:format', $page_arguments['source_page_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -381,13 +386,18 @@ class UGUpdateNews7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_news_body:summary', $news_arguments['source_news_summary']);
 
 		// News Body Format
-		if($news_arguments['source_news_body'] == 'body'){
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_news_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($news_arguments['source_news_body'] == 'body'){
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_news_body:format', $news_arguments['source_news_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -442,13 +452,18 @@ class UGUpdateEvent7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_event_body:summary', $event_arguments['source_event_summary']);
 
 		// Event Body Format
-		if($event_arguments['source_event_body'] == 'body'){
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_event_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($event_arguments['source_event_body'] == 'body'){
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_event_body:format', $event_arguments['source_event_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -502,13 +517,18 @@ class UGUpdateFAQ7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_faq_answer', $faq_arguments['source_faq_answer']);
 
 		// FAQ Answer Format
-		if($faq_arguments['source_faq_answer'] == 'body'){
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_faq_answer:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($faq_arguments['source_faq_answer'] == 'body'){
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_faq_answer:format', $faq_arguments['source_faq_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 }
@@ -568,13 +588,18 @@ class UGUpdateFeaturedItem7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_feature_link', $featureditem_arguments['source_featureditem_link']);
 
 		// Featured Item Body Format
-		if($featureditem_arguments['source_featureditem_body'] == 'body'){
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_feature_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($featureditem_arguments['source_featureditem_body'] == 'body'){
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_feature_text:format', $featureditem_arguments['source_featureditem_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
     }
 
@@ -747,13 +772,18 @@ class UGUpdateProfile7Migration extends UGUpdate7Migration {
 		$this->addFieldMapping('field_profile_summary', $profile_arguments['source_profile_summary']);
 
 		// Profile Summary Format
-		if($profile_arguments['source_profile_summary'] == 'body'){
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_profile_summary:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($profile_arguments['source_profile_summary'] == 'body'){
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_profile_summary:format', $profile_arguments['source_profile_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 	}
 }
@@ -809,13 +839,18 @@ class UGUpdateBanner7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_banner_text', $banner_arguments['source_banner_text']);
 
 		// Banner Text Format
-		if($banner_arguments['source_banner_text'] == 'body'){
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_banner_text:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-			$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($banner_arguments['source_banner_text'] == 'body'){
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+				$this->addFieldMapping('field_banner_text:format', $banner_arguments['source_banner_text_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 
     }
@@ -886,13 +921,18 @@ class UGUpdateCourseOutline7Migration extends UGUpdate7Migration {
 	    $this->addFieldMapping('field_course_body:summary', $course_arguments['source_course_summary']);
 
 		// Course Outline Body Format
-		if($course_arguments['source_course_body'] == 'body'){
-		    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-			    ->defaultValue('full_html');
+		if($this->arguments['override_format'] == TRUE){
+			$this->addFieldMapping('field_course_body:format')
+				->defaultValue($this->arguments['default_format']);
 		}else{
-		    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
-			    ->callbacks(array($this, 'mapFormat'))
-			    ->defaultValue('full_html');
+			if($course_arguments['source_course_body'] == 'body'){
+			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+				    ->defaultValue($this->arguments['default_format']);
+			}else{
+			    $this->addFieldMapping( 'field_course_body:format', $course_arguments['source_course_format'])
+				    ->callbacks(array($this, 'mapFormat'))
+				    ->defaultValue($this->arguments['default_format']);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #539 

In order to migrate all formats as filtered_html (ie. override the source format), the person migrating can go into their site-specific migration configuration file and:
- set the variable "default_format" to the format they wish to migrate to (eg. filtered_html)
- set the variable "override_format" to TRUE

![migrate-settings-filtered](https://cloud.githubusercontent.com/assets/1927902/24812823/a36d65fa-1b99-11e7-9e7b-4cf03b38b7a2.png)

Default behaviour remains to migrate the source format to the destination format (so if half the items on the source site are filtered_html and half are full_html, you will find the same on the migrated destination site). This allows us to migrate sites with their format intact, rather than setting a format which could potentially strip content if people saved.

---
# Demo

## Source site
![migrate-news-1-before](https://cloud.githubusercontent.com/assets/1927902/24812575/a726a9c8-1b98-11e7-9d25-9c782b2b0b61.png)

```

mysql> select body_format from field_data_body where bundle="article";
+---------------+
| body_format   |
+---------------+
| filtered_html |
| filtered_html |
| filtered_html |
| filtered_html |
| full_html     |
| plain_text    |
| full_html     |
| filtered_html |
| plain_text    |
| filtered_html |
| full_html     |
| filtered_html |
| full_html     |
| filtered_html |
| filtered_html |
| full_html     |
| plain_text    |
| full_html     |
| plain_text    |
| full_html     |
| filtered_html |
| plain_text    |
| full_html     |
| full_html     |
| filtered_html |
| full_html     |
| filtered_html |
| filtered_html |
| filtered_html |
| plain_text    |
| filtered_html |
| full_html     |
| filtered_html |
| filtered_html |
| plain_text    |
| plain_text    |
| custom_format |
| plain_text    |
| plain_text    |
| plain_text    |
| filtered_html |
| plain_text    |
| filtered_html |
| plain_text    |
| filtered_html |
| plain_text    |
| full_html     |
| full_html     |
| plain_text    |
| full_html     |
| filtered_html |
+---------------+
51 rows in set (0.00 sec)
```

## Destination Site
![migrate-news-2-after](https://cloud.githubusercontent.com/assets/1927902/24812659/ef7bf0ac-1b98-11e7-80f0-9df3a13c417a.png)

```
mysql> select field_news_body_format from field_data_field_news_body;
+------------------------+
| field_news_body_format |
+------------------------+
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
| filtered_html          |
+------------------------+
51 rows in set (0.00 sec)
```

---

# Testing Process
- open the site-specific migrate_settings configuration file
- set the variable "default_format" to filtered_html
- set the variable "override_format" to TRUE 
- migrate a site with a variety of source formats
- check in the database -- all your formats should now be filtered_html