### PR TITLE
Issue 655 - Hide filter when no terms are in use

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -538,7 +538,7 @@ function ug_theme_field__field_service_private_heading($variables) {
  *	Implements hook_views_pre_render
  */
 function ug_theme_views_pre_render(&$view) {
-	if($view->name == 'pp1') {
+	if($view->name == 'pp1' || $view->name == 'pp4' || $view->name == 'pp6') {
 		$tids = array();
 		foreach($view->result as $result) {
 			$node = node_load($result->nid);
@@ -549,7 +549,7 @@ function ug_theme_views_pre_render(&$view) {
 			}
 		}
 
-		if(empty($tids)) {
+		if(empty($tids) && isset($view->exposed_widgets)) {
 			$dom = new DOMDocument('1.0', 'utf-8');
 			$dom->loadHTML($view->exposed_widgets);
 			$node = $dom->getElementById('edit-field-profile-role-tid-wrapper');

--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -534,6 +534,31 @@ function ug_theme_field__field_service_private_heading($variables) {
   return '<h3>'.drupal_render($variables['items'][0]).'</h3>';
 }
 
+/**
+ *	Implements hook_views_pre_render
+ */
+function ug_theme_views_pre_render(&$view) {
+	if($view->name == 'pp1') {
+		$tids = array();
+		foreach($view->result as $result) {
+			$node = node_load($result->nid);
+
+			if(!empty($node->field_profile_role)) {
+				$tid = $node->field_profile_role[LANGUAGE_NONE][0]['tid'];
+				$tids[$tid] = isset($tids[$tid]) ? $tids[$tid]++ : 1;
+			}
+		}
+
+		if(empty($tids)) {
+			$dom = new DOMDocument('1.0', 'utf-8');
+			$dom->loadHTML($view->exposed_widgets);
+			$node = $dom->getElementById('edit-field-profile-role-tid-wrapper');
+			$node->parentNode->removeChild($node);
+			$view->exposed_widgets = $dom->saveHTML();
+		}
+	}
+}
+
  
 /**
  * Returns HTML for a date element formatted as a single date.


### PR DESCRIPTION
Fixes #655.

Overrides hook_views_pre_render and filters HTML form output if there are no results with taxonomy term.

## Test Procedure
For each [pp1, pp1:nopic, pp4, pp6]:
1. Check view with no profiles, ensure no 'role' filter
![pp1_no_profiles](https://cloud.githubusercontent.com/assets/25013998/24968393/15294b66-1f7b-11e7-90fd-ed9c1b2a29b0.png)

2. Add profile tagged with any role, ensure 'role' filter appears
![pp1_tagged_profile](https://cloud.githubusercontent.com/assets/25013998/24968399/1a73e130-1f7b-11e7-8b49-ef09d745b7de.png)

3. Untag profile, ensure no 'role' filter
![pp1_untagged_profile](https://cloud.githubusercontent.com/assets/25013998/24968414/2402888c-1f7b-11e7-916f-36c42b2e73c9.png)

4. The above steps should prove the override works, but feel free to test various combinations of tagged and untagged profiles and ensuring the filter appears so long as there is at least one profile tagged with any role and disappears otherwise.