### PR TITLE
Issue 677 - Disable UG Breadcrumbs and Crumbs

### DIFF
--- a/profiles/ug/modules/ug/ug_path_breadcrumbs/ug_path_breadcrumbs.path_breadcrumbs.inc
+++ b/profiles/ug/modules/ug/ug_path_breadcrumbs/ug_path_breadcrumbs.path_breadcrumbs.inc
@@ -80,7 +80,7 @@ function ug_path_breadcrumbs_path_breadcrumbs_settings_info() {
           'name' => 'path_visibility',
           'settings' => array(
             'visibility_setting' => '1',
-            'paths' => 'faqs/*',
+            'paths' => 'faq/*',
           ),
           'context' => 'empty',
           'not' => FALSE,

--- a/profiles/ug/ug.info
+++ b/profiles/ug/ug.info
@@ -26,7 +26,6 @@ dependencies[] = search
 dependencies[] = shortcut
 dependencies[] = toolbar
 dependencies[] = ug_banner
-dependencies[] = ug_breadcrumbs
 dependencies[] = ug_course_outline_layouts
 dependencies[] = ug_course_outlines
 dependencies[] = ug_date_format

--- a/profiles/ug/ug.install
+++ b/profiles/ug/ug.install
@@ -57,3 +57,9 @@ function ug_update_7700(&$sandbox) {
   }
 }
 
+/**
+ * Disable UG Breadcrumbs and Crumbs modules
+ */
+function ug_update_7701(&$sandbox) {
+  module_disable(array('ug_breadcrumbs', 'crumbs'));
+}


### PR DESCRIPTION
Fixes #677.

Added update hook to ug.install to disable the module on any existing sites. New sites will have both modules disabled by default as UG Breadcrumbs was removed as a dependency from ug.info.

## Test Procedure
1. Checkout master branch
2. Install new site, ensure the UG Breadcrumbs and Crumbs modules are enabled
3. Checkout branch iss677 and run `drush updb`
4. Ensure the UG Breadcrumbs and Crumbs modules are now disabled
5. Reinstall site on branch iss677 and ensure UG Breadcrumbs and Crumbs are disabled by default for new installs
6. While the modules are disabled, ensure the breadcrumbs on all content types are still intact and working as normal