### PR TITLE
Issue 275 - Add styles to remove list numbers and padding in search results

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -168,6 +168,11 @@ Base Styles
     border-bottom: 1px solid #EFEFEF;
   }
 
+  ol.search-results {
+    padding:0;
+    list-style:none;
+  }
+
   /*---------------------
   Images
   ---------------------**/


### PR DESCRIPTION
Fixes #275.

Removes numbers and padding from the \<ol\> that contains the search results.

## Test Procedure
1. Checkout branch `iss275`
2. Generate content types
3. Search for a word in the title of one of the generated nodes
4. Ensure the search results look something like this:

![search-results-no-numbers](https://cloud.githubusercontent.com/assets/25013998/25150203/1a73778a-244f-11e7-9b2c-d2558a44df5b.png)

NOT like this:
![search-results-with-numbers](https://cloud.githubusercontent.com/assets/25013998/25150226/33f42b8c-244f-11e7-98a0-0b3a399de33a.png)
