### PR TITLE
Turn on UG responsive tables filter for full HTML

### DIFF
--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
@@ -545,6 +545,11 @@ th[colspan|rowspan|headers|scope|abbr|sorted],',
     'status' => 1,
     'weight' => -9,
     'filters' => array(
+      'ug_tables' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(),
+      ),
       'pathologic' => array(
         'weight' => 50,
         'status' => 1,


### PR DESCRIPTION
Fixes #673. 

Enabled "UG Responsive Tables" filter at admin/config/formats/full_html.

## Test Procedure

1. Create a Full HTML basic page and add a table. Do not add any classes.  Save the page.
2. Inspect the table and confirm that the responsive class is present.
3. Edit the page again, and this time add the responsive class. Save the page.
4. Inspect the table again and confirm that the responsive tables filter has removed the responsive class you added. 