### PR TITLE
Issue 494 - Course Outlines detail page should hide field label if no associated content exists (eg. Term, Instructor)

### DIFF
--- a/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
+++ b/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
@@ -28,7 +28,7 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
   /**
    * Test "Course Outlines" listing page.
    */
-  function testCourseListing() {
+  function _testCourseListing() {
 
     $site_name =  variable_get('site_name', 'Drupal');
 
@@ -90,7 +90,7 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
   /**
    * Test URL aliases.
    */
-  function testUrlAlias() {
+  function _testUrlAlias() {
     /* Create a node */
     $settings = array('type' => 'course_outline');
     $name = $settings['field_course_name'][LANGUAGE_NONE][0]['value'] = $this->randomName();
@@ -103,5 +103,19 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
     $this->assertUrl($expected_path);
   }
 
-}
 
+  /**
+  * Tests if the labels 'term' & 'instructor' are hidden when blank
+  */
+  function testHiddenLabels() {
+    $settings = array('type' => 'course_outline');
+    $name = $settings['field_course_name'][LANGUAGE_NONE][0]['value'] = $this->randomName();
+    $code = $settings['field_course_code'][LANGUAGE_NONE][0]['value'] = $this->randomName();
+    $node1 = $this->drupalCreateNode($settings);
+    $this->drupalGet('node/' . $node1->nid);
+  
+    $this->assertNoText(t('Term:'), 'The \'Term:\' text does not appear when field is blank');
+    $this->assertNoText(t('Instructor:'), 'The \'Instructor:\' text does not appear when field is blank');
+  }
+
+}

--- a/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
+++ b/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.test
@@ -28,7 +28,7 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
   /**
    * Test "Course Outlines" listing page.
    */
-  function _testCourseListing() {
+  function testCourseListing() {
 
     $site_name =  variable_get('site_name', 'Drupal');
 
@@ -90,7 +90,7 @@ class UGCourseOutlinesTestCase extends TaxonomyWebTestCase {
   /**
    * Test URL aliases.
    */
-  function _testUrlAlias() {
+  function testUrlAlias() {
     /* Create a node */
     $settings = array('type' => 'course_outline');
     $name = $settings['field_course_name'][LANGUAGE_NONE][0]['value'] = $this->randomName();

--- a/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.views_default.inc
+++ b/profiles/ug/modules/ug/ug_course_outlines/ug_course_outlines.views_default.inc
@@ -329,50 +329,54 @@ function ug_course_outlines_views_default_views() {
   $handler->display->display_options['fields']['field_course_code']['label'] = '';
   $handler->display->display_options['fields']['field_course_code']['exclude'] = TRUE;
   $handler->display->display_options['fields']['field_course_code']['element_label_colon'] = FALSE;
-  /* Field: Content: Course term */
-  $handler->display->display_options['fields']['field_course_term']['id'] = 'field_course_term';
-  $handler->display->display_options['fields']['field_course_term']['table'] = 'field_data_field_course_term';
-  $handler->display->display_options['fields']['field_course_term']['field'] = 'field_course_term';
-  $handler->display->display_options['fields']['field_course_term']['label'] = '';
-  $handler->display->display_options['fields']['field_course_term']['exclude'] = TRUE;
-  $handler->display->display_options['fields']['field_course_term']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_course_term']['type'] = 'taxonomy_term_reference_plain';
   /* Field: Content: Section */
   $handler->display->display_options['fields']['field_course_section']['id'] = 'field_course_section';
   $handler->display->display_options['fields']['field_course_section']['table'] = 'field_data_field_course_section';
   $handler->display->display_options['fields']['field_course_section']['field'] = 'field_course_section';
   $handler->display->display_options['fields']['field_course_section']['label'] = '';
-  $handler->display->display_options['fields']['field_course_section']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_course_section']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_course_section']['alter']['text'] = '<p class="media-condensed"><strong>Code and section:</strong> [field_course_code]*[field_course_section]</p>';
   $handler->display->display_options['fields']['field_course_section']['element_label_colon'] = FALSE;
+  /* Field: Content: Course term */
+  $handler->display->display_options['fields']['field_course_term']['id'] = 'field_course_term';
+  $handler->display->display_options['fields']['field_course_term']['table'] = 'field_data_field_course_term';
+  $handler->display->display_options['fields']['field_course_term']['field'] = 'field_course_term';
+  $handler->display->display_options['fields']['field_course_term']['label'] = '';
+  $handler->display->display_options['fields']['field_course_term']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_course_term']['alter']['text'] = '<p class="media-condensed"><strong>Term:</strong> [field_course_term]</p>';
+  $handler->display->display_options['fields']['field_course_term']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_course_term']['type'] = 'taxonomy_term_reference_plain';
   /* Field: Content: Course instructor */
   $handler->display->display_options['fields']['field_course_instructor']['id'] = 'field_course_instructor';
   $handler->display->display_options['fields']['field_course_instructor']['table'] = 'field_data_field_course_instructor';
   $handler->display->display_options['fields']['field_course_instructor']['field'] = 'field_course_instructor';
   $handler->display->display_options['fields']['field_course_instructor']['label'] = '';
   $handler->display->display_options['fields']['field_course_instructor']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_course_instructor']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_course_instructor']['alter']['text'] = '<p><strong>Instructor:</strong> [field_course_instructor]</p>';
   $handler->display->display_options['fields']['field_course_instructor']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_course_instructor']['type'] = 'text_plain';
+  /* Field: Content: Course instructor name only */
+  $handler->display->display_options['fields']['field_course_instructor_1']['id'] = 'field_course_instructor_1';
+  $handler->display->display_options['fields']['field_course_instructor_1']['table'] = 'field_data_field_course_instructor';
+  $handler->display->display_options['fields']['field_course_instructor_1']['field'] = 'field_course_instructor';
+  $handler->display->display_options['fields']['field_course_instructor_1']['ui_name'] = 'Content: Course instructor name only';
+  $handler->display->display_options['fields']['field_course_instructor_1']['label'] = '';
+  $handler->display->display_options['fields']['field_course_instructor_1']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_course_instructor_1']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_course_instructor_1']['type'] = 'text_plain';
   /* Field: Content: Course instructor url */
   $handler->display->display_options['fields']['field_course_instructor_url']['id'] = 'field_course_instructor_url';
   $handler->display->display_options['fields']['field_course_instructor_url']['table'] = 'field_data_field_course_instructor_url';
   $handler->display->display_options['fields']['field_course_instructor_url']['field'] = 'field_course_instructor_url';
   $handler->display->display_options['fields']['field_course_instructor_url']['label'] = '';
-  $handler->display->display_options['fields']['field_course_instructor_url']['exclude'] = TRUE;
   $handler->display->display_options['fields']['field_course_instructor_url']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['field_course_instructor_url']['alter']['text'] = '<a href="[field_course_instructor_url-url]">[field_course_instructor]</a>';
+  $handler->display->display_options['fields']['field_course_instructor_url']['alter']['text'] = '<p><strong>Instructor:</strong> <a href="[field_course_instructor_url-url]">[field_course_instructor_1]</a></p>';
   $handler->display->display_options['fields']['field_course_instructor_url']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_course_instructor_url']['empty'] = '[field_course_instructor]';
+  $handler->display->display_options['fields']['field_course_instructor_url']['hide_empty'] = TRUE;
   $handler->display->display_options['fields']['field_course_instructor_url']['click_sort_column'] = 'url';
   $handler->display->display_options['fields']['field_course_instructor_url']['type'] = 'link_plain';
-  /* Field: Global: Custom text */
-  $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
-  $handler->display->display_options['fields']['nothing']['table'] = 'views';
-  $handler->display->display_options['fields']['nothing']['field'] = 'nothing';
-  $handler->display->display_options['fields']['nothing']['label'] = '';
-  $handler->display->display_options['fields']['nothing']['alter']['text'] = '<p class="media-condensed"><strong>Code and section:</strong> [field_course_code]*[field_course_section]</p>
-<p class="media-condensed"><strong>Term:</strong> [field_course_term]</p>
-<p><strong>Instructor:</strong> [field_course_instructor_url]</p>
-';
-  $handler->display->display_options['fields']['nothing']['element_label_colon'] = FALSE;
   /* Field: Content: Details */
   $handler->display->display_options['fields']['field_course_body']['id'] = 'field_course_body';
   $handler->display->display_options['fields']['field_course_body']['table'] = 'field_data_field_course_body';


### PR DESCRIPTION
Fixes #494 

Comment from @tqureshi-uog describing fix:
> @bdavey07 See attached code - it works by selectively rewriting and hiding results, i.e.

> **Section and term:** rewrite results of field with proper formatting, hide rewriting if empty

> **Instructor:** rewrite results `<p><strong>Instructor:</strong> [field_course_instructor]</p>`, hide rewriting if empty

> **Instructor, name only:** this is a plain text field (excluded from display, no rewriting) used for link text, token [field_course_instructor_1]

> **Instructor url:** No results text set to [field_course_instructor], hide if empty, hide rewriting if empty. Rewritten output is `<p><strong>Instructor:</strong> <a href="[field_course_instructor_url-url]"[field_course_instructor_1]</a></p>` (that is, if there's no value for instructor url, output the rewritten instructor name contained in token [field_course_instructor] whereas if a value does exist for instructor > url, output a link using the Instructor name only token as link text)

# Testing Process
## Manual
- Create Course outline with neither Term nor Instructor
- Create Course outline with Term but no Instructor
- Create Course outline with Instructor but no Term
- Create Course outline with Instructor and Term
- Ensure labels for the Instructor and Term only show up when a value is given in each case

## Automated
- Run UG simpletest (this pull request includes the test that was committed in ccswbs/hjckrrh/pull/579)
- I am currently working on a Testcafe test for this fix
