### PR TITLE
Issue 669 - Add filter to make images automatically responsive

### DIFF
--- a/profiles/ug/modules/ug/ug_filter/ug_filter.module
+++ b/profiles/ug/modules/ug/ug_filter/ug_filter.module
@@ -5,6 +5,11 @@
       'description' => t('Wraps tables with bootstrap responsive class.'),
       'process callback' => '_ug_table_process',
     );
+    $filters['ug_images'] = array(
+      'title' => t('UG Responsive Images'),
+      'description' => t('Adds img-responsive class to image tags.'),
+      'process callback' => '_ug_image_process',
+    );
     return $filters;
   }
   
@@ -15,5 +20,15 @@
     // Collapse duplicate responsive wrappers
     $text = preg_replace("/(<div class=\"table-responsive\">\s*){2,}(<table.*?>.*?<\/div>\s*?<\/div>)/s", "<div class=\"table-responsive\">$2", $text);
     
+    return $text;
+  }
+
+  function _ug_image_process($text, $filter, $format) {
+    // Add .img-responsive to img tags that completely lack the class attribute
+    $text = preg_replace("/(<img )(?!.*class=\".*\".*)(.*?>)/s", "$1 class=\"img-responsive\" $2", $text);
+
+    // Add .img-responsive to img tags that have exising, non-relevant classes
+    $text = preg_replace("/(<img.*?class=\"(?>(?!img-responsive).)*?)(\".*?>)/s", "$1 img-responsive$2", $text);
+
     return $text;
   }

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
@@ -18,6 +18,11 @@ function ug_wysiwyg_filter_default_formats() {
     'status' => 1,
     'weight' => -10,
     'filters' => array(
+      'ug_images' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(),
+      ),
       'ug_tables' => array(
         'weight' => 0,
         'status' => 1,
@@ -545,6 +550,11 @@ th[colspan|rowspan|headers|scope|abbr|sorted],',
     'status' => 1,
     'weight' => -9,
     'filters' => array(
+      'ug_images' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(),
+      ),
       'pathologic' => array(
         'weight' => 50,
         'status' => 1,


### PR DESCRIPTION
Fixes #669.

Adds "UG Responsive Images" filter to both filtered_html and full_html.

## Test Procedure
Follow these same steps for both filtered_html and full_html:
1. Create a node with an image in the body
    - Ensure the source contains `class="img-responsive"` that was automatically added by CKEditor
2. View the page source and ensure the image has a single img-responsive class (ie. not `class="img-responsive img-responsive"`)
3. Edit the page through CKEditor source view and add a class to the img tag
    - Choose a class that is allowed by the text format. `img-rounded`, `img-thumbnail`, `img-circle`, and `sr-only` are good choices for filtered_html
4. View the page source again and make sure the class you added manually is still present along with `img-responsive`
5. Edit the page one more time and remove the class attribute entirely
6. Make sure `class="img-responsive"` appears in the page source