### PR TITLE
Issue #156 BK1 - Markup validation error

### DIFF
--- a/modules/book/book.module
+++ b/modules/book/book.module
@@ -1109,13 +1109,6 @@ function template_preprocess_book_navigation(&$variables) {
       $variables['prev_title'] = check_plain($prev['title']);
     }
 
-    if ($book_link['plid'] && $parent = book_link_load($book_link['plid'])) {
-      $parent_href = url($parent['href']);
-      drupal_add_html_head_link(array('rel' => 'up', 'href' => $parent_href));
-      $variables['parent_url'] = $parent_href;
-      $variables['parent_title'] = check_plain($parent['title']);
-    }
-
     if ($next = book_next($book_link)) {
       $next_href = url($next['href']);
       drupal_add_html_head_link(array('rel' => 'next', 'href' => $next_href));


### PR DESCRIPTION
Fixes issue #156 

As per @nevantan recommendation, removes preprocess function that adds the up link.

## Test Procedure
- Create some book pages and a book to put them in
- Check all the pages to see that the Up link no longer exsists

I intend to write a testcafe test for this