### PR TITLE
Fix SimpleTest for profiles' last name search

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.test
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.test
@@ -24,7 +24,7 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
     theme_enable(array('ug_cornerstone'));
     theme_disable(array('bartik'));
     variable_set('theme_default', 'ug_theme');
-    
+
     /* Allow creation of Drupal accounts. */
     $ldap_conf = variable_get('ldap_authentication_conf');
     $ldap_conf['authenticationMode'] = 1;
@@ -81,7 +81,7 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
     /* Assert content type exists. */
     $this->assertTrue(node_type_get_type('profile'));
     /* Assert custom field exists (assume the rest are there). */
-    $this->assertNotNull(field_info_field('field_profile_address'));    
+    $this->assertNotNull(field_info_field('field_profile_address'));
     /* Disable and uninstall the feature. */
     module_disable(array('ug_profile', 'ug_profile_layouts'));
     drupal_uninstall_modules(array('ug_profile', 'ug_profile_layouts'));
@@ -111,37 +111,37 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
   }
 
   /**
-   * Test office label in teaser 
+   * Test office label in teaser
    */
   function testOfficeLabel() {
     // Generate data
     $name = $this->randomName();
     $lastname = $this->randomName();
     $office = $this->randomName();
-    
+
     // Create node
     $settings = array('type' => 'profile');
     $settings['field_profile_name'][LANGUAGE_NONE][0]['value'] = $name;
     $settings['field_profile_lastname'][LANGUAGE_NONE][0]['value'] = $lastname;
     $node = $this->drupalCreateNode($settings);
-    
+
     // Get listing page
     $this->drupalGet('people/');
-    
+
     // Test office not present
     $this->assertNoText("Office:");
-    
+
     // Add node
     $settings['field_profile_office'][LANGUAGE_NONE][0]['value'] = $office;
     $node2 = $this->drupalCreateNode($settings);
-    
+
     // Get listing page
     $this->drupalGet('people/');
-    
+
     // Test office present
     $this->assertText("Office:");
   }
-  
+
   /**
    * Test Last Name Search
    */
@@ -149,13 +149,13 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
     // Fetch terms
     $vocab = taxonomy_vocabulary_machine_name_load('profile_role');
     $terms = taxonomy_term_load_multiple(array(), array("vid" => $vocab->vid));
-    
+
     // Extract Term IDs
     $tids = array();
     foreach($terms as $term) {
       array_push($tids, $term->tid);
     }
-    
+
     // Get data
     $count = 25;
     $data = json_decode(@file_get_contents("https://randomuser.me/api/?inc=name&results=$count&nat=gb"), true);
@@ -168,7 +168,7 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
         ));
       }
     }
-    
+
     // Create nodes
     $settings = array('type' => 'profile');
     $nodes = array();
@@ -176,19 +176,19 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
     foreach($data['results'] as $profile) {
       // Choose random role
       $tid = $tids[rand(0, count($tids) - 1)];
-      
+
       // Default to random last name
       $lastname = ucfirst($profile['name']['last']);
       // Force at least one duplicate last name for testing purposes
       if($processed == 0 || $processed == 1) {
         $lastname = "Smith";
       }
-      
+
       // Create node
       $settings['field_profile_name'][LANGUAGE_NONE][0]['value'] = ucfirst($profile['name']['first']);
       $settings['field_profile_lastname'][LANGUAGE_NONE][0]['value'] = $lastname;
       $settings['field_profile_role'][LANGUAGE_NONE][0]['tid'] = $tid;
-      
+
       // Store node object and associted information
       array_push($nodes,
         array(
@@ -198,47 +198,47 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
           'lastname' => $lastname
         )
       );
-      
+
       // Increment tracking number
       $processed++;
     }
-    
+
     // Filter by just last name
     foreach($nodes as $node) {
       // Store last name (because $node reference is reused)
       $lastname = $node['lastname'];
-      
+
       // Set GET parameters and navigate to search page
       $options = array('query' => array('field_profile_role_tid' => 'All', 'field_profile_lastname_value' => $lastname, 'undefined' => 'Apply'));
       $this->drupalGet('people/', $options);
-      
+
       // Check each profile
       foreach($nodes as $node) {
         $name = $node['firstname'].' '.$node['lastname'];
-        if($node['lastname'] == $lastname) {
+        if($node['lastname'] == $lastname || strpos(strtolower($node['lastname']), strtolower($lastname)) === 0) {
           $this->assertText($name, $name.' found with search term \''.$lastname.'\'.', 'Filter by Last Name');
         } else {
           $this->assertNoText($name, $name.' not found with search term \''.$lastname.'\'.', 'Filter by Last Name');
         }
       }
     }
-    
+
     // Filter by just partial last name
     foreach($nodes as $node) {
       // Store last name
       $lastname = $node['lastname'];
-      
+
       // Select random fragment from beginning of last name
       $search = substr($lastname, 0, rand(2, strlen($lastname) - 2));
-      
+
       // Set GET parameters and navigate to search page
       $options = array('query' => array('field_profile_role_tid' => 'All', 'field_profile_lastname_value' => $search, 'undefined' => 'Apply'));
       $this->drupalGet('people/', $options);
-      
+
       // Check each profile
       foreach($nodes as $node) {
         $name = $node['firstname'].' '.$node['lastname'];
-        
+
         // If lastname begins with search term
         if(strpos(strtolower($node['lastname']), strtolower($search)) === 0) {
           $this->assertText($name, $name.' found with search term \''.$search.'\'.', 'Filter by Partial Last Name');
@@ -247,17 +247,17 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
         }
       }
     }
-    
+
     // Filter by just role
     for($i = 0; $i < count($tids); $i++) {
       // Set GET parameters and navigate to search page
       $options = array('query' => array('field_profile_role_tid' => $tids[$i], 'field_profile_lastname_value' => '', 'undefined' => 'Apply'));
       $this->drupalGet('people/', $options);
-      
+
       // Check each profile
       foreach($nodes as $node) {
         $name = $node['firstname'].' '.$node['lastname'];
-        
+
         // If profile has the current term ID
         if($node['tid'] == $tids[$i]) {
           $this->assertText($name, $name.' found.', 'Filter by Role');
@@ -266,7 +266,7 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
         }
       }
     }
-    
+
     // Filter by both last name and role
     // NOTE: Too many operations to loop through every combination of term and last name - select random sample instead
     $samples = 10;
@@ -277,11 +277,11 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
       $search = substr($lastname, 0, rand(2, strlen($lastname) - 2));
       // Select random term
       $tid = $tids[rand(0, count($tids) - 1)];
-      
+
       // Set GET parameters and navigate to search page
       $options = array('query' => array('field_profile_role_tid' => $tid, 'field_profile_lastname_value' => $search, 'undefined' => 'Apply'));
       $this->drupalGet('people/', $options);
-      
+
       // Check every profile
       foreach($nodes as $node) {
         $name = $node['firstname'].' '.$node['lastname'];
@@ -292,18 +292,18 @@ class UGProfileTestCase extends TaxonomyWebTestCase {
         }
       }
     }
-    
+
     // Filter by single letter
     $alphabet = array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z');
     foreach($alphabet as $letter) {
       // Set GET parameters and navigate to search page
       $options = array('query' => array('field_profile_role_tid' => 'All', 'field_profile_lastname_value' => $letter, 'undefined' => 'Apply'));
       $this->drupalGet('people/', $options);
-      
+
       // Check each profile
       foreach($nodes as $node) {
         $name = $node['firstname'].' '.$node['lastname'];
-        
+
         // If lastname begins with the current letter
         if(strpos(strtolower($node['lastname']), strtolower($letter)) === 0) {
           $this->assertText($name, $name.' found with search term \''.$letter.'\'.', 'Filter by Single Letter');


### PR DESCRIPTION
Add an additional check when searching for full last names to deal with cases where one last name is a substring of another (e.g. Martin and Martinez).

## Test Procedure
1. Checkout `iss736`
2. Add the following snippet (which forces the Martin/Martinez case, feel free to change the last names to test other cases) to ug_profile.test:205:
```
    // TEST: Create node 1
    $settings = array('type' => 'profile');
    $settings['field_profile_name'][LANGUAGE_NONE][0]['value'] = ucfirst('john');
    $settings['field_profile_lastname'][LANGUAGE_NONE][0]['value'] = 'Martin';
    $settings['field_profile_role'][LANGUAGE_NONE][0]['tid'] = $tids[0];
    array_push($nodes,
      array(
        'node' => $this->drupalCreateNode($settings),
        'tid' => $tids[0],
        'firstname' => ucfirst('john'),
        'lastname' => 'Martin'
      )
    );

    // TEST: Create node 2
    $settings = array('type' => 'profile');
    $settings['field_profile_name'][LANGUAGE_NONE][0]['value'] = ucfirst('jane');
    $settings['field_profile_lastname'][LANGUAGE_NONE][0]['value'] = 'Martinez';
    $settings['field_profile_role'][LANGUAGE_NONE][0]['tid'] = $tids[0];
    array_push($nodes,
      array(
        'node' => $this->drupalCreateNode($settings),
        'tid' => $tids[0],
        'firstname' => ucfirst('jane'),
        'lastname' => 'Martinez'
      )
    );
```
3. Run UG Profile SimpleTests (recommend: underscore all tests other than `testLastNameSearch`)
4. Ensure test passes