### PR TITLE
Issue 752 - Banner color contrast

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -583,7 +583,6 @@ Base Styles
 
   p {
     word-wrap: break-word;
-    color:#2C2727;
   }
   
 /*---------------------


### PR DESCRIPTION
Fixes the banner color contrast issue by removing the dark color from the `<p>` css rule rather than spot-fixing by overwriting the color in specific cases.