### PR TITLE
[Next] Fix issue with certain characters being escaped in PP6 names

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -261,7 +261,7 @@ function ug_theme_preprocess_views_view_fields__pp6(&$vars) {
   $vars['phone']          = $vars['fields']['field_profile_telephonenumber']->content;
   $vars['email']          = $vars['fields']['field_profile_email']->content;
   $vars['user_url']       = 'user/'.$vars['nid'];
-  $vars['fullname']       = l($vars['name'].' '.$vars['lastname'], 'node/'.$vars['nid']);
+  $vars['fullname']       = t('<a href="@url">'.$vars['name'].' '.$vars['lastname'].'</a>', array('@url' => url('node/'.$vars['nid'])));
   $vars['office']         = $vars['fields']['field_profile_office']->content;
   $vars['content_width']  = 'col-md-12';
   $vars['content_offset'] = '';


### PR DESCRIPTION
**Issue:** Names in PP6 are having special characters escaped before they display which causes problems with names like O'Halloran:
![pp6_escaping_issue](https://user-images.githubusercontent.com/25013998/27926774-9531e128-6257-11e7-9a80-0eb427935423.png)

The PP6 pre-process function in template.php was using the `l()` method to concatenate the first and last names and wrap them in an `<a>` tag. This method also seems to escape the contents, which is what's causing the problem.

## Test Procedure
1. Setup `/people` with a PP6 view
2. Add a profile that has a special character in either the first or last name fields
3. Ensure the special character is rendered correctly and not escaped