### PR TITLE
Patch for Services Module 3.20

### DIFF
--- a/profiles/ug/drupal-org.make
+++ b/profiles/ug/drupal-org.make
@@ -169,6 +169,7 @@ projects[rules][patch][] = "https://www.drupal.org/files/issues/rules-fix-fatal-
 projects[scanner][version] = "1.0-beta1"
 
 projects[services][version] = "3.20"
+projects[services][patch][] = "patches/services.patch"
 
 projects[strongarm][version] = "2.0"
 

--- a/profiles/ug/patches/services.patch
+++ b/profiles/ug/patches/services.patch
@@ -1,0 +1,18 @@
+diff --git a/resources/taxonomy_resource.inc b/resources/taxonomy_resource.inc
+index 074f791..e75b3a0 100644
+--- a/resources/taxonomy_resource.inc
++++ b/resources/taxonomy_resource.inc
+@@ -393,7 +393,12 @@ function _taxonomy_term_resource_create($term) {
+   $term = _services_arg_value($term, 'term');
+
+   $term = (object)$term;
+-  return taxonomy_term_save($term);
++
++  if (taxonomy_term_save($term) == 1) {
++    return array("tid" => $term->tid);
++  } else {
++    return services_error(t('Unable to create new taxonomy term. Please contact administrator'), 404);
++  }
+ }
+
+ /**

--- a/sites/all/modules/services/resources/taxonomy_resource.inc
+++ b/sites/all/modules/services/resources/taxonomy_resource.inc
@@ -393,7 +393,12 @@ function _taxonomy_term_resource_create($term) {
   $term = _services_arg_value($term, 'term');
 
   $term = (object)$term;
-  return taxonomy_term_save($term);
+
+  if (taxonomy_term_save($term) == 1) {
+    return array("tid" => $term->tid);
+  } else {
+    return services_error(t('Unable to create new taxonomy term. Please contact administrator'), 404);
+  }
 }
 
 /**


### PR DESCRIPTION
Replacing #775 as a cleaner solution that includes the Services 3.20 update (the referenced pull request uses Services 3.19).  

Changes the services module to return the value of the term ID rather than the success code.
