### PR TITLE
Replace Old Cornerstone Logo

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
@@ -3,7 +3,7 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="container-fluid">
       <div class="navbar-header">
-        <a class="navbar-brand" href="http://www.uoguelph.ca/"><img alt="University of Guelph" src="//www.uoguelph.ca/img/universityofguelph.gif"></a>
+        <a class="navbar-brand" href="http://www.uoguelph.ca/"><img alt="University of Guelph" src="//www.uoguelph.ca/img/universityofguelph.png"></a>
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#ug-navbar" aria-expanded="false" aria-controls="navbar"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button>
       </div>
       <div id="ug-navbar" class="navbar-collapse collapse" tabindex="-1">


### PR DESCRIPTION
This branch replaces the old logo with the new link. See before/after screenshots attached:
![old-logo](https://user-images.githubusercontent.com/25013998/28434503-8929ffd0-6d5d-11e7-9250-cee705ffc868.png)
![new-logo](https://user-images.githubusercontent.com/25013998/28434529-a016014e-6d5d-11e7-9689-2d7dacdefbb4.png)
