### PR TITLE
[Master] Issue 791 - Siteimprove Issue: Naming Generic Landmarks

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
@@ -142,16 +142,16 @@
   <div class="row">
 
     <?php if (empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-12">
+      <div class="col-sm-12">
     <?php endif; ?>
     <?php if (empty($variables['page']['sidebar_first']) && !empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-9">
+      <div class="col-sm-9">
     <?php endif; ?>
     <?php if (!empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-9 col-sm-push-3">
+      <div class="col-sm-9 col-sm-push-3">
     <?php endif; ?>
     <?php if (!empty($variables['page']['sidebar_first']) && !empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-6 col-sm-push-3">
+      <div class="col-sm-6 col-sm-push-3">
     <?php endif; ?>
 
       <?php if (!empty($page['highlighted'])): ?>
@@ -175,7 +175,7 @@
         <ul class="action-links"><?php print render($action_links); ?></ul>
       <?php endif; ?>
       <?php print render($page['content']); ?>
-    </section>
+    </div>
 
     <?php if (!empty($page['sidebar_first'])): ?>
       <?php if (!empty($page['sidebar_second'])): ?>

--- a/profiles/ug/themes/ug/ug_theme/templates/block.tpl.php
+++ b/profiles/ug/themes/ug/ug_theme/templates/block.tpl.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - $block->subject: Block title.
+ * - $content: Block content.
+ * - $block->module: Module that generated the block.
+ * - $block->delta: An ID for the block, unique within each module.
+ * - $block->region: The block region embedding the current block.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. The default values can be one or more of the
+ *   following:
+ *   - block: The current template type, i.e., "theming hook".
+ *   - block-[module]: The module generating the block. For example, the user
+ *     module is responsible for handling the default user navigation block. In
+ *     that case the class would be 'block-user'.
+ * - $title_prefix (array): An array containing additional output populated by
+ *   modules, intended to be displayed in front of the main title tag that
+ *   appears in the template.
+ * - $title_suffix (array): An array containing additional output populated by
+ *   modules, intended to be displayed after the main title tag that appears in
+ *   the template.
+ *
+ * Helper variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ * - $block_zebra: Outputs 'odd' and 'even' dependent on each block region.
+ * - $zebra: Same output as $block_zebra but independent of any block region.
+ * - $block_id: Counter dependent on each block region.
+ * - $id: Same output as $block_id but independent of any block region.
+ * - $is_front: Flags true when presented in the front page.
+ * - $logged_in: Flags true when the current user is a logged-in member.
+ * - $is_admin: Flags true when the current user is an administrator.
+ * - $block_html_id: A valid HTML ID and guaranteed unique.
+ *
+ * @see bootstrap_preprocess_block()
+ * @see template_preprocess()
+ * @see template_preprocess_block()
+ * @see bootstrap_process_block()
+ * @see template_process()
+ *
+ * @ingroup templates
+ */
+?>
+<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php print render($title_prefix); ?>
+  <?php if ($title): ?>
+    <h2<?php print $title_attributes; ?>><?php print $title; ?></h2>
+  <?php endif;?>
+  <?php print render($title_suffix); ?>
+
+  <?php print $content ?>
+
+</div>


### PR DESCRIPTION
Fixes #791

Recreating #798 against master.

---

Replaced `<section>` tags in the block and page templates with `<div>` tags. Both are generic tags, but the latter does not implicitly gain the `role="region"` attribute.

## Manual Testing
1. Checkout `iss791` branch
2. Ctrl + F the inspector for section tags
3. Visually compare the site to a site running master to ensure no styles broke when the tags were changed