### PR TITLE
Remove toolbar and ensure nothing else in the header moves

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
+++ b/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
@@ -110,6 +110,11 @@ Live Date: June 23, 2015
 	        border-top-color: #FFFFFF;
 	    }
 
+	    /* Provide spacing between search bar and top of page */
+	    #ug-navbar {
+	    	padding-top:30px;
+	    }
+
 		@media all and (min-width: 768px){
 
 			/* Menu Tabs CLOSED - FOCUS/HOVER styling (Wide) */

--- a/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
+++ b/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
@@ -111,9 +111,11 @@ Live Date: June 23, 2015
 	    }
 
 	    /* Provide spacing between search bar and top of page */
-	    #ug-navbar {
-	    	padding-top:30px;
-	    }
+	    @media (min-width: 765px) {
+			#toptoolbuttons {
+			    visibility: hidden;
+			}
+		}
 
 		@media all and (min-width: 768px){
 

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
@@ -7,20 +7,7 @@
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#ug-navbar" aria-expanded="false" aria-controls="navbar"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button>
       </div>
       <div id="ug-navbar" class="navbar-collapse collapse" tabindex="-1">
-        <ul class="nav navbar-nav navbar-right navbar-small">
-          <li><a href="https://mail.uoguelph.ca/"><span class="glyphicon glyphicon-envelope fa-fw" aria-hidden="true"></span> GryphMail</a></li>
-          <li><a href="https://courselink.uoguelph.ca/"><span class="glyphicon glyphicon-pencil fa-fw" aria-hidden="true"></span> CourseLink</a></li>
-          <li><a href="//www.uoguelph.ca/directory/"><span class="glyphicon glyphicon-user fa-fw" aria-hidden="true"></span> Directory <span class="sr-only">for University of Guelph</span></a></li>
-          <li><a href="//www.lib.uoguelph.ca"><span class="glyphicon glyphicon-book fa-fw" aria-hidden="true"></span> Library</a></li>
-          <li><a href="//www.uoguelph.ca/campus/map/"><span class="glyphicon glyphicon-road fa-fw" aria-hidden="true"></span> Maps</a></li>
-          <li><a href="https://gryphlife.uoguelph.ca"><span class="fa fa-users fa-fw" aria-hidden="true"></span> Gryphlife</a></li>
-      <li><a href="//webadvisor.uoguelph.ca/"><span class="glyphicon glyphicon-list-alt fa-fw" aria-hidden="true"></span> WebAdvisor</a></li>
-          <li><a href="http://weather.gc.ca/city/pages/on-5_metric_e.html"><span class="glyphicon glyphicon-cloud fa-fw" aria-hidden="true"></span> <span class="sr-only">Guelph </span>Weather</a></li>
-
-        </ul>
-
-
-        <form class="navbar-form navbar-right" role="form" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
+        <form class="navbar-form navbar-right mt-3" role="form" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
           <input type="hidden" name="commonname" class="search1" id="searchtext2">
           <input type="hidden" name="vl(freeText0)" class="search1" id="searchtext3">
           <input type="hidden" name="cx" value="011117603928904778939:tp3ks5ha2dw">

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
@@ -7,7 +7,20 @@
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#ug-navbar" aria-expanded="false" aria-controls="navbar"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button>
       </div>
       <div id="ug-navbar" class="navbar-collapse collapse" tabindex="-1">
-        <form class="navbar-form navbar-right mt-3" role="form" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
+        <ul id="toptoolbuttons" class="nav navbar-nav navbar-right navbar-small">
+          <li><a href="https://mail.uoguelph.ca/"><span class="glyphicon glyphicon-envelope fa-fw" aria-hidden="true"></span> GryphMail</a></li>
+          <li><a href="https://courselink.uoguelph.ca/"><span class="glyphicon glyphicon-pencil fa-fw" aria-hidden="true"></span> CourseLink</a></li>
+          <li><a href="//www.uoguelph.ca/directory/"><span class="glyphicon glyphicon-user fa-fw" aria-hidden="true"></span> Directory <span class="sr-only">for University of Guelph</span></a></li>
+          <li><a href="//www.lib.uoguelph.ca"><span class="glyphicon glyphicon-book fa-fw" aria-hidden="true"></span> Library</a></li>
+          <li><a href="//www.uoguelph.ca/campus/map/"><span class="glyphicon glyphicon-road fa-fw" aria-hidden="true"></span> Maps</a></li>
+          <li><a href="https://gryphlife.uoguelph.ca"><span class="fa fa-users fa-fw" aria-hidden="true"></span> Gryphlife</a></li>
+      <li><a href="//webadvisor.uoguelph.ca/"><span class="glyphicon glyphicon-list-alt fa-fw" aria-hidden="true"></span> WebAdvisor</a></li>
+          <li><a href="http://weather.gc.ca/city/pages/on-5_metric_e.html"><span class="glyphicon glyphicon-cloud fa-fw" aria-hidden="true"></span> <span class="sr-only">Guelph </span>Weather</a></li>
+
+        </ul>
+
+
+        <form class="navbar-form navbar-right" role="form" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
           <input type="hidden" name="commonname" class="search1" id="searchtext2">
           <input type="hidden" name="vl(freeText0)" class="search1" id="searchtext3">
           <input type="hidden" name="cx" value="011117603928904778939:tp3ks5ha2dw">


### PR DESCRIPTION
Removing the toolbar at the top caused the search bar to sit flush against the top of the page. I ended up adding a padding to the top of the `#ug-navbar` element to create a gap the same height as the toolbar. This padding doesn't move the logo because the logo is actually in a sibling container to the navigation.