### PR TITLE
[Master] Issue 806 - Fix Accordion Script

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_instance.inc
@@ -260,7 +260,7 @@ function ug_profile_field_default_field_instances() {
     'label' => 'Attachments',
     'required' => 0,
     'settings' => array(
-      'description_field' => 0,
+      'description_field' => 1,
       'file_directory' => '',
       'file_extensions' => 'txt pdf doc docs odt ppt pps docx dotx ppsx pptx xlsx xltx mp3',
       'max_filesize' => '',

--- a/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
+++ b/profiles/ug/themes/ug/ug_cornerstone/css/ug2015-v1.css
@@ -244,6 +244,17 @@ Live Date: June 23, 2015
 		margin-right: 15px;
 	}
 
+	#ug-front-h1 {
+		margin-top:0;
+		margin-bottom:0;
+		font-size:1em;
+		font-weight:normal;
+	}
+
+	#ug-front-h1 a:hover {
+		border-bottom:0 !important;
+	}
+
 	@media all and (min-width: 992px){
 		/* Right align the last two menu dropdown items */
     	#navbar.navbar-inverse .navbar-nav>li.dropdown:nth-last-child(-n+2)>ul{

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
@@ -85,7 +85,9 @@
         <?php endif; ?>
 
         <?php if (!empty($site_name)): ?>
-        <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+          <?php if($is_front): ?><h1 id="ug-front-h1"><?php endif; ?>
+            <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+          <?php if($is_front): ?></h1><?php endif; ?>
         <?php endif; ?>
         <?php if (!empty($site_slogan)): ?>
         <p class="lead"><?php print $site_slogan; ?></p>

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
@@ -142,16 +142,16 @@
   <div class="row">
 
     <?php if (empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-12">
+      <div class="col-sm-12">
     <?php endif; ?>
     <?php if (empty($variables['page']['sidebar_first']) && !empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-9">
+      <div class="col-sm-9">
     <?php endif; ?>
     <?php if (!empty($variables['page']['sidebar_first']) && empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-9 col-sm-push-3">
+      <div class="col-sm-9 col-sm-push-3">
     <?php endif; ?>
     <?php if (!empty($variables['page']['sidebar_first']) && !empty($variables['page']['sidebar_second'])): ?>
-      <section class="col-sm-6 col-sm-push-3">
+      <div class="col-sm-6 col-sm-push-3">
     <?php endif; ?>
 
       <?php if (!empty($page['highlighted'])): ?>
@@ -175,7 +175,7 @@
         <ul class="action-links"><?php print render($action_links); ?></ul>
       <?php endif; ?>
       <?php print render($page['content']); ?>
-    </section>
+    </div>
 
     <?php if (!empty($page['sidebar_first'])): ?>
       <?php if (!empty($page['sidebar_second'])): ?>

--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -703,3 +703,18 @@ _:-ms-fullscreen, :root .carousel-table a.glyphicon {
 .ctools-modal-dialog .modal-body #edit-admin-description-wrapper {
   height:auto;
 }
+
+/* For the plus/minus icons on expandible/collapsible content */
+
+a[data-toggle="collapse"]:before {
+    /* symbol for "opening" panels */
+    font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
+    font-size: 0.7em;
+    content: "\2212";    /* adjust as needed, taken from bootstrap.css */
+    color: inherit;         /* adjust as needed */
+    padding-right: 0.3em;
+}
+a[data-toggle="collapse"].collapsed:before {
+    /* symbol for "collapsed" panels */
+    content: "\2b";    /* adjust as needed, taken from bootstrap.css */
+}

--- a/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
+++ b/profiles/ug/themes/ug/ug_theme/js/ug_scripts.js
@@ -18,8 +18,7 @@ jQuery(function($) {
 			controller.attr("aria-controls", $(elem).attr("id"));
 			controller.attr("data-toggle", "collapse");
 
-			// If controller is a link, also set href to target id
-			if(controller.get(0).tagName.toLowerCase() == "a") controller.attr("href", $(elem).attr("id"));
+			controller.removeAttr('href');
 		});
 	});
 });

--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -262,7 +262,7 @@ function ug_theme_preprocess_views_view_fields__pp6(&$vars) {
   $vars['phone']          = $vars['fields']['field_profile_telephonenumber']->content;
   $vars['email']          = $vars['fields']['field_profile_email']->content;
   $vars['user_url']       = 'user/'.$vars['nid'];
-  $vars['fullname']       = l($vars['name'].' '.$vars['lastname'], 'node/'.$vars['nid']);
+  $vars['fullname']       = t('<a href="@url">'.$vars['name'].' '.$vars['lastname'].'</a>', array('@url' => url('node/'.$vars['nid'])));
   $vars['office']         = $vars['fields']['field_profile_office']->content;
   $vars['content_width']  = 'col-md-12';
   $vars['content_offset'] = '';

--- a/profiles/ug/themes/ug/ug_theme/templates/block.tpl.php
+++ b/profiles/ug/themes/ug/ug_theme/templates/block.tpl.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - $block->subject: Block title.
+ * - $content: Block content.
+ * - $block->module: Module that generated the block.
+ * - $block->delta: An ID for the block, unique within each module.
+ * - $block->region: The block region embedding the current block.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. The default values can be one or more of the
+ *   following:
+ *   - block: The current template type, i.e., "theming hook".
+ *   - block-[module]: The module generating the block. For example, the user
+ *     module is responsible for handling the default user navigation block. In
+ *     that case the class would be 'block-user'.
+ * - $title_prefix (array): An array containing additional output populated by
+ *   modules, intended to be displayed in front of the main title tag that
+ *   appears in the template.
+ * - $title_suffix (array): An array containing additional output populated by
+ *   modules, intended to be displayed after the main title tag that appears in
+ *   the template.
+ *
+ * Helper variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ * - $block_zebra: Outputs 'odd' and 'even' dependent on each block region.
+ * - $zebra: Same output as $block_zebra but independent of any block region.
+ * - $block_id: Counter dependent on each block region.
+ * - $id: Same output as $block_id but independent of any block region.
+ * - $is_front: Flags true when presented in the front page.
+ * - $logged_in: Flags true when the current user is a logged-in member.
+ * - $is_admin: Flags true when the current user is an administrator.
+ * - $block_html_id: A valid HTML ID and guaranteed unique.
+ *
+ * @see bootstrap_preprocess_block()
+ * @see template_preprocess()
+ * @see template_preprocess_block()
+ * @see bootstrap_process_block()
+ * @see template_process()
+ *
+ * @ingroup templates
+ */
+?>
+<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <?php print render($title_prefix); ?>
+  <?php if ($title): ?>
+    <h2<?php print $title_attributes; ?>><?php print $title; ?></h2>
+  <?php endif;?>
+  <?php print render($title_suffix); ?>
+
+  <?php print $content ?>
+
+</div>


### PR DESCRIPTION
FIxes #806

Recreating #808 against master.

Accordion script currently looks for `data-target` attributes on `<a class="collapse">` links and automatically sets the `href` of the element to match the target. It was setting the value incorrectly though, which caused the accordion controller to navigate to another page.

This pull request removes the line altogether because a controller using the `<a>` tag only requires an `href` attribute as a fallback for no JavaScript, so there is no point is setting the attribute with JavaScript.

## Manual Test Procedure
- Create a page with an accordion structure (see https://aoda-test.web.uoguelph.ca/ccs/accordion-test for an example and https://github.com/ccswbs/hjckrrh/pull/735 for more information)
- Create an `<a>` controller with both `data-target` and `href` set
- Create an `<a>` controller with only `data-target` set (note that this is not ideal because it has no fallback, but it should still work)
- Ensure both the controllers properly expand/collapse their respective sections