### PR TITLE
[Master] Change category field to multiselect (UG Profile)[fixes #783]

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_base.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.features.field_base.inc
@@ -117,7 +117,7 @@ function ug_profile_field_default_field_bases() {
   // Exported field_base: 'field_profile_category'.
   $field_bases['field_profile_category'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_profile_category',


### PR DESCRIPTION
Changes category field to multiselect (UG Profile)[fixes #783].

# Manual Testing procedure
- Add two profile categories (categoryA, categoryB)
- Add a new profile and confirm that both categoryA and categoryB can be selected for that single node
- Navigate to people/tag/[categoryA term ID] and confirm profile is showing in the list
- Navigate to people/tag/[categoryB term ID] and confirm profile is showing in the list

# Automated Testing procedure
- TestCafe test available at https://github.com/ccswbs/testing/pull/65 - ```testcafe chrome ug_profile.test.js -t "Categories are multiselect"```