### PR TITLE
Issue 816 - Add empty alt attribute to profile images on PP1B view

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.info
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.info
@@ -5,7 +5,6 @@ package = UG
 version = 7.x-7.52
 project = ug_profile
 dependencies[] = auto_nodetitle
-dependencies[] = ds
 dependencies[] = ds_bootstrap_layouts
 dependencies[] = field_collection
 dependencies[] = field_group

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
@@ -351,7 +351,7 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['nothing']['label'] = '';
   $handler->display->display_options['fields']['nothing']['alter']['text'] = '<figure class="face-figure pull-left">
 <a href="[path]">
-<img src=[field_profile_image] />
+<img alt src=[field_profile_image] />
 <figcaption class="face-caption">
 <h2>[field_profile_name] [field_profile_lastname]</h2> 
 <p>[field_profile_role]</p>


### PR DESCRIPTION
Modified the "Custom Text" field of the PP1B view and added an "alt" attribute to the image. This attribute is blank as the profile already has text associated with it. This should resolve SiteImprove errors surrounding missing alt-text on the 140 faces view.