### PR TITLE
CSS for img overlay

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/features.css
+++ b/profiles/ug/themes/ug/ug_theme/css/features.css
@@ -324,19 +324,25 @@ PP - People profiles
   140 Faces-style grid view
   -----------------------------------------------*/
 
-figure.face-figure {
+figure.face-figure, .img-overlay {
     position: relative;
     z-index: 0;
     float: left !important;
     margin: 0 !important;
     overflow: hidden;
     padding: 0;
-    height: 142px;
-    width: 142px;
     background-color: #111;
 }
+figure.face-figure {
+    height: 142px;
+    width: 142px;
+}
+.img-overlay {
+    min-height: 100px;
+    min-width: 100px;
+}
 
-figure.face-figure img {
+figure.face-figure img, .img-overlay img {
     position: relative;
     z-index: 2;
     opacity: 1;
@@ -344,14 +350,13 @@ figure.face-figure img {
     transition: opacity 400ms ease;
 }
 
-figure.face-figure figcaption.face-caption {
+figure.face-figure figcaption.face-caption, .overlay-caption {
     position :absolute;
     z-index: 1;
     top: 0;
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 142px;
     color: #fff !important;
     background-color: transparent;
     text-align: left !important;
@@ -359,13 +364,22 @@ figure.face-figure figcaption.face-caption {
     -webkit-transition: z-index 400ms;
     transition: z-index 400ms;
 }
+figure.face-figure figcaption.face-caption {
+    height: 142px;
+}
+.overlay-caption {
+    height: inherit;
+}
 
 figure.face-figure a:hover img,
-figure.face-figure a:focus img {
+figure.face-figure a:focus img,
+.img-overlay a:hover img,
+.img-overlay a:focus img {
     opacity: 0.33;
 }
 figure.face-figure a:hover figcaption.face-caption,
-figure.face-figure a:focus figcaption.face-caption {
+figure.face-figure a:focus figcaption.face-caption,
+.overlay-caption {
     z-index: 3;
 }
 
@@ -393,4 +407,3 @@ figure.face-figure a:focus figcaption.face-caption {
 .field-name-field-profile-image img {
   margin-bottom: 2em;
 }
-

--- a/profiles/ug/themes/ug/ug_theme/css/features.css
+++ b/profiles/ug/themes/ug/ug_theme/css/features.css
@@ -337,9 +337,11 @@ figure.face-figure {
     height: 142px;
     width: 142px;
 }
-.img-overlay {
-    min-height: 100px;
-    min-width: 100px;
+.img-overlay a {
+    display: block;
+    min-width: 150px;
+    color: #fff !important;
+    text-shadow: 1px 1px 2px black, 0 0 1em black, 0 0 0.2em black;
 }
 
 figure.face-figure img, .img-overlay img {
@@ -349,9 +351,14 @@ figure.face-figure img, .img-overlay img {
     -webkit-transition: opacity 400ms ease;
     transition: opacity 400ms ease;
 }
+.img-overlay img {
+    line-height: 150px;
+    background-color: black;
+    font-weight: bold;
+}
 
 figure.face-figure figcaption.face-caption, .overlay-caption {
-    position :absolute;
+    position: absolute;
     z-index: 1;
     top: 0;
     bottom: 0;
@@ -361,6 +368,7 @@ figure.face-figure figcaption.face-caption, .overlay-caption {
     background-color: transparent;
     text-align: left !important;
     margin: 0;
+    padding: 5px;
     -webkit-transition: z-index 400ms;
     transition: z-index 400ms;
 }
@@ -379,8 +387,19 @@ figure.face-figure a:focus img,
 }
 figure.face-figure a:hover figcaption.face-caption,
 figure.face-figure a:focus figcaption.face-caption,
-.overlay-caption {
+.img-overlay a:hover .overlay-caption,
+.img-overlay a:focus .overlay-caption {
     z-index: 3;
+}
+
+.ug-red {
+    background-color: #C20430 !important;
+}
+.ug-blue {
+    background-color: #69A3B9 !important;
+}
+.ug-gold {
+    background-color: #FFC72A !important;
 }
 
 .views-exposed-widgets {
@@ -405,5 +424,14 @@ figure.face-figure a:focus figcaption.face-caption,
 }
 
 .field-name-field-profile-image img {
-  margin-bottom: 2em;
+    margin-bottom: 2em;
+}
+
+.overlay-text {
+    position: absolute;
+    bottom: 0;
+    left: 5px;
+}
+.text-white {
+    color: #ffffff;
 }


### PR DESCRIPTION
These changes allow the Notable Alumni-style grid view to be used on images other than those for People Profiles. The classes require Full HTML access, but can be applied to basic page content via CKeditor (as opposed to Notable Alumni, which was generated by a View)

To test, copy the source code from here: https://dev.web.uoguelph.ca/tqdev/image-overlay

Experiment with different-sized images and broken images (i.e. to see if alt text shows up properly)