### PR TITLE
Fix broken search and hide duplicate search button [fixes #606]

### DIFF
--- a/profiles/ug/modules/ug/ug_search/ug_search.features.user_permission.inc
+++ b/profiles/ug/modules/ug/ug_search/ug_search.features.user_permission.inc
@@ -23,10 +23,7 @@ function ug_search_user_default_permissions() {
   // Exported permission: 'use advanced search'.
   $permissions['use advanced search'] = array(
     'name' => 'use advanced search',
-    'roles' => array(
-      'anonymous user' => 'anonymous user',
-      'authenticated user' => 'authenticated user',
-    ),
+    'roles' => array(),
     'module' => 'search',
   );
 

--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -1152,14 +1152,29 @@ function ug_theme_feed_icon($variables) {
 }
 
 /**
+* Overrides bootstrap_form_alter()
 *
+*  Fixes Issue 606 - By default, Bootstrap hides a 2nd Drupal-generated Search button.
+*  This fix ensures assistive tech users can also ignore this invisible button.
 */
+
 function ug_theme_form_alter(array &$form, array &$form_state = array(), $form_id = NULL) {
-  bootstrap_form_alter($form, $form_state, $form_id);
-  if($form_id == 'search_form') {
-    unset($form['basic']['submit']);
-  } else if ($form_id == 'search_block_form') {
-    $classes = &$form['actions']['submit']['#attributes']['class'];
-    $form['actions']['#attributes']['class'][] = 'element-hidden';
+
+  switch ($form_id){
+    case 'search_form':
+      $class_array = &$form['basic']['submit']['#attributes']['class'];
+      break;
+    case 'search_block_form':
+      $class_array = &$form['actions']['submit']['#attributes']['class'];
+      break;
+  }
+
+  if(isset($class_array)){
+    //Use Bootstrap hidden class instead of element-invisible
+    foreach ($class_array as $key => $value) {
+      if($value === 'element-invisible'){
+        $class_array[$key] = 'hidden';
+      }
+    }
   }
 }

--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -1003,7 +1003,7 @@ function ug_theme_bootstrap_search_form_wrapper($variables) {
   $output = '<div class="input-group">';
 
 //added
-    $output .= '<label for="edit-search-block-form--2" class="element-invisible">Search this site</label>';
+    $output .= '<label for="'.$variables['element']['#id'].'" class="element-invisible">Search this site</label>';
 
   $output .= $variables['element']['#children'];
   $output .= '<span class="input-group-btn">';


### PR DESCRIPTION
Test branch iss606-fix on Github.

**Check the following:**
- Search box (local) on Search Results page
![image](https://user-images.githubusercontent.com/1927902/46818092-5f036000-cd4e-11e8-9343-584cd654ad64.png)
- Search box (local) on general node pages
![image](https://user-images.githubusercontent.com/1927902/46818101-67f43180-cd4e-11e8-9522-d87ead765d63.png)
- Search box (local) anywhere else you can think of

**Ensure that:**
- Anything searched in the (local) search box gives out a result
- When you listen with a screen-reader, you only hear one "Search button" as opposed to two. Also ensure that you cannot tab to a second hidden Search button right after the first one.
- There is an explicit label (for - id) association for both the breadcrumb search box and on the search results page