### PR TITLE
Update landmarks / remove redundant WAI-ARIA labels (fixes #510)

### DIFF
--- a/profiles/ug/themes/ug/ug_cornerstone/templates/html.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/html.tpl.php
@@ -63,10 +63,10 @@
   </noscript>
 </head>
 <body class="<?php print $classes; ?>" <?php print $attributes;?>>
-  <div id="skip-link">
-    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
-  </div>
-  <?php include('includes/ug-header.inc'); ?>
+  <nav id="skip-link" aria-label="Skip links"> 
+   <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </nav>    
+<?php include('includes/ug-header.inc'); ?>
   <?php print $page_top; ?>
   <?php print $page; ?>
   <?php print $page_bottom; ?>

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-footer.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-footer.inc
@@ -1,6 +1,6 @@
 <div id="ug-footer-global">
   <div class="container">
-    <footer role="contentinfo" class="row navbar navbar-inverse">
+    <footer aria-label="University of Guelph main" class="row navbar navbar-inverse">
       <div class="col-lg-12">
         <ul class="nav navbar-nav navbar-right">
           <li><a href="//www.uoguelph.ca/accessibility/"><span class="fa fa-wheelchair"></span> Accessibility<span class="sr-only"> at University of Guelph</span></a></li>

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/includes/ug-header.inc
@@ -1,6 +1,6 @@
 <div id="ug-header"><div class="container"> 
   <!-- Static navbar -->
-  <nav class="navbar navbar-default navbar-static-top" role="navigation" aria-label="University of Guelph main website navigtion">
+  <nav class="navbar navbar-default navbar-static-top" aria-label="University of Guelph main">
     <div class="container-fluid">
       <div class="navbar-header">
         <a class="navbar-brand" href="http://www.uoguelph.ca/"><img alt="University of Guelph" src="//www.uoguelph.ca/img/universityofguelph.png"></a>
@@ -20,7 +20,7 @@
         </ul>
 
 
-        <form class="navbar-form navbar-right" role="search" aria-label="University of Guelph main web site search form" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
+        <form class="navbar-form navbar-right" role="search" id="searchbox_011117603928904778939:tp3ks5ha2dw" name="searchform" action="//www.uoguelph.ca/search/">
           <input type="hidden" name="commonname" class="search1" id="searchtext2">
           <input type="hidden" name="vl(freeText0)" class="search1" id="searchtext3">
           <input type="hidden" name="cx" value="011117603928904778939:tp3ks5ha2dw">

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/page--search.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/page--search.tpl.php
@@ -73,7 +73,7 @@
  * @ingroup themeable
  */
 ?>
-<header id="navbar" role="banner" class="<?php print $navbar_classes; ?>">
+<header id="navbar" class="<?php print $navbar_classes; ?>">
   <div class="container">
     <div class="flex-container">
 
@@ -102,7 +102,7 @@
 
       <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
         <div id="primary-nav" class="navbar-collapse collapse flex-bottom flex-right ">
-          <nav role="navigation">
+          <nav aria-label="<?php print $site_name; ?>">
             <?php if (!empty($primary_nav)): ?>
               <?php print render($primary_nav); ?>
             <?php endif; ?>
@@ -119,21 +119,22 @@
   </div>
 </header>
 
-<header id="page-header">
+<section id="page-header" aria-label="Page header">
   <div class="container">
     <?php print render($page['header']); ?>
   </div>
-</header> <!-- /#page-header -->
+</section> <!-- /#page-header -->
 
+<main>
 <div class="main-container container">
-
-
 
   <?php if (!empty($breadcrumb)): ?>
     <div class="row search-and-breadcrumb">
-      <div class="col-sm-12">
-        <?php print $breadcrumb; ?>
-      </div>
+      <nav aria-label="breadcrumb">
+        <div class="col-sm-12">
+          <?php print $breadcrumb; ?>
+        </div>
+    </nav> 
    </div>
   <?php endif; ?>
 
@@ -193,8 +194,9 @@
 
   </div>
 </div>
+</main>
 <div id="ug-footer-local">
-  <footer class="footer container">
+  <footer aria-label="<?php print variable_get('site_name'); ?>" class="footer container">
     <?php print render($page['footer']); ?>
   </footer>
 </div>

--- a/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
+++ b/profiles/ug/themes/ug/ug_cornerstone/templates/page.tpl.php
@@ -102,7 +102,7 @@
 
       <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
         <div id="primary-nav" class="navbar-collapse collapse flex-bottom flex-right ">
-          <nav role="navigation aria-label="website <?php print $site_name; ?> navigation">
+          <nav aria-label="<?php print $site_name; ?>">
             <?php if (!empty($primary_nav)): ?>
               <?php print render($primary_nav); ?>
             <?php endif; ?>
@@ -119,28 +119,26 @@
   </div>
 </header>
 
-<header id="page-header" role="banner">
+<section id="page-header" aria-label="Page header">
   <div class="container">
     <?php print render($page['header']); ?>
   </div>
-</header> <!-- /#page-header -->
+</section> <!-- /#page-header -->
 
-<main role="main">
+<main>
 <div class="main-container container">
-
-
 
   <?php if (!empty($breadcrumb)): ?>
     <div class="row search-and-breadcrumb">
-    <section role="region" aria-label="breadcrumb navigation">
-      <div class="col-sm-9">
-        <?php print $breadcrumb; ?>
-      </div>
-      <div class="col-sm-3">
-        <?php $block = module_invoke('search', 'block_view', 'form');
-        print render($block['content']); ?>
-     </div>
-   </section> 
+      <nav aria-label="breadcrumb">
+        <div class="col-sm-9">
+          <?php print $breadcrumb; ?>
+        </div>
+        <div class="col-sm-3">
+          <?php $block = module_invoke('search', 'block_view', 'form');
+          print render($block['content']); ?>
+        </div>
+    </nav> 
    </div>
   <?php endif; ?>
 
@@ -202,9 +200,7 @@
 </div>
 </main>
 <div id="ug-footer-local">
-<section role="Region" aria-label="primary footer region">	
-  <footer class="footer container">
+  <footer aria-label="<?php print variable_get('site_name'); ?>" class="footer container">
     <?php print render($page['footer']); ?>
   </footer>
-</section>
 </div>


### PR DESCRIPTION
Fixes should:
- add skip link landmark
- update labels for landmarks
- remove Siteimprove warnings related to landmarks (see #510 )

When testing:
- check with Siteimprove
- check with HTML validator
- check with screen-reader