### PR TITLE
Add mp3, ogg to allowed file list: news, event, page

### DIFF
--- a/profiles/ug/modules/ug/ug_event/ug_event.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_event/ug_event.features.field_instance.inc
@@ -109,7 +109,7 @@ function ug_event_field_default_field_instances() {
     'settings' => array(
       'description_field' => 1,
       'file_directory' => '',
-      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv vtt',
+      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv vtt mp3 ogg',
       'max_filesize' => '',
       'user_register_form' => FALSE,
     ),

--- a/profiles/ug/modules/ug/ug_news/ug_news.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_news/ug_news.features.field_instance.inc
@@ -37,7 +37,7 @@ function ug_news_field_default_field_instances() {
     'settings' => array(
       'description_field' => 1,
       'file_directory' => '',
-      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv dmg vtt',
+      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv dmg vtt mp3 ogg',
       'max_filesize' => '',
       'user_register_form' => FALSE,
     ),

--- a/profiles/ug/modules/ug/ug_page/ug_page.features.field_instance.inc
+++ b/profiles/ug/modules/ug/ug_page/ug_page.features.field_instance.inc
@@ -37,7 +37,7 @@ function ug_page_field_default_field_instances() {
     'settings' => array(
       'description_field' => 1,
       'file_directory' => '',
-      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv dmg vtt',
+      'file_extensions' => 'txt pdf doc docx rtf png gif jpg jpeg zip xls xlsx ppt pptx csv dmg vtt mp3 ogg',
       'max_filesize' => '',
       'user_register_form' => FALSE,
     ),


### PR DESCRIPTION
Cherry-picked Joy's update on filetypes from branch iss767-update-fontawesome (see https://github.com/ccswbs/hjckrrh/pull/884).