### PR TITLE
Remove Fontawesome library from makefile

### DIFF
--- a/profiles/ug/drupal-org.make
+++ b/profiles/ug/drupal-org.make
@@ -83,10 +83,6 @@ projects[flag][version] = "3.9"
 projects[flood_control][version] = "1.0"
 
 projects[fontawesome][version] = "3.7"
-libraries[fontawesome][download][type] = "git"
-libraries[fontawesome][download][url] = "https://github.com/FortAwesome/Font-Awesome.git"
-libraries[fontawesome][directory_name] = "fontawesome"
-libraries[fontawesome][destination] = "libraries"
 
 projects[google_analytics][version] = "2.3"
 


### PR DESCRIPTION
We're getting the following error when packaging fontawesome:

```
The library 'fontawesome' cannot be downloaded from                                             [error]
https://github.com/FortAwesome/Font-Awesome.git, the URL must be in the whitelist available at
https://www.drupal.org/packaging-whitelist.
The Drupal.org validation check failed -- see https://www.drupal.org/node/1432190 for more      [error]
information.
```
This removes the reference in the makefile so the validation check will pass.