### PR TITLE
Adding images symlink to fix tcpdf permission issue

### DIFF
--- a/sites/all/libraries/tcpdf/images
+++ b/sites/all/libraries/tcpdf/images
@@ -1,0 +1,1 @@
+../../../default/files/print_pdf/


### PR DESCRIPTION
Print module doesn't use images folder from tcpdf library, but we need this symlink to skip permissions check from drupal status page.