### PR TITLE
Add keywords as optional field on PP6 custom view

### DIFF
--- a/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
@@ -836,6 +836,9 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['field_profile_website']['field'] = 'field_profile_website';
   $handler->display->display_options['fields']['field_profile_website']['label'] = 'Website';
   $handler->display->display_options['fields']['field_profile_website']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_profile_website']['element_type'] = 'span';
+  $handler->display->display_options['fields']['field_profile_website']['element_label_type'] = 'strong';
+  $handler->display->display_options['fields']['field_profile_website']['element_wrapper_type'] = 'div';
   $handler->display->display_options['fields']['field_profile_website']['hide_empty'] = TRUE;
   $handler->display->display_options['fields']['field_profile_website']['click_sort_column'] = 'url';
   $handler->display->display_options['fields']['field_profile_website']['delta_offset'] = '0';

--- a/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
+++ b/profiles/ug/modules/ug/ug_profile/ug_profile.views_default.inc
@@ -839,6 +839,17 @@ function ug_profile_views_default_views() {
   $handler->display->display_options['fields']['field_profile_website']['hide_empty'] = TRUE;
   $handler->display->display_options['fields']['field_profile_website']['click_sort_column'] = 'url';
   $handler->display->display_options['fields']['field_profile_website']['delta_offset'] = '0';
+  /* Field: Content: Keywords */
+  $handler->display->display_options['fields']['field_tags']['id'] = 'field_tags';
+  $handler->display->display_options['fields']['field_tags']['table'] = 'field_data_field_tags';
+  $handler->display->display_options['fields']['field_tags']['field'] = 'field_tags';
+  $handler->display->display_options['fields']['field_tags']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_tags']['element_type'] = 'span';
+  $handler->display->display_options['fields']['field_tags']['element_label_type'] = 'strong';
+  $handler->display->display_options['fields']['field_tags']['element_wrapper_type'] = 'div';
+  $handler->display->display_options['fields']['field_tags']['hide_empty'] = TRUE;
+  $handler->display->display_options['fields']['field_tags']['type'] = 'taxonomy_term_reference_plain';
+  $handler->display->display_options['fields']['field_tags']['delta_offset'] = '0';
   /* Sort criterion: Content: Last name (field_profile_lastname) */
   $handler->display->display_options['sorts']['field_profile_lastname_value']['id'] = 'field_profile_lastname_value';
   $handler->display->display_options['sorts']['field_profile_lastname_value']['table'] = 'field_data_field_profile_lastname';

--- a/profiles/ug/themes/ug/ug_theme/template.php
+++ b/profiles/ug/themes/ug/ug_theme/template.php
@@ -295,13 +295,14 @@ function ug_theme_preprocess_views_view_fields__pp6(&$vars) {
   $vars['firstname']      = (isset($vars['fields']['field_profile_name'])            ? $vars['fields']['field_profile_name']->content : '');
   $vars['lastname']       = (isset($vars['fields']['field_profile_lastname'])        ? $vars['fields']['field_profile_lastname']->content : '');
   $vars['teaser']         = (isset($vars['fields']['field_profile_teaser'])          ? $vars['fields']['field_profile_teaser']->content : '');
-  $vars['summary']         = (isset($vars['fields']['field_profile_summary'])          ? $vars['fields']['field_profile_summary']->content : '');
+  $vars['summary']        = (isset($vars['fields']['field_profile_summary'])         ? $vars['fields']['field_profile_summary']->content : '');
   $vars['phone']          = (isset($vars['fields']['field_profile_telephonenumber']) ? $vars['fields']['field_profile_telephonenumber']->content : '');
   $vars['email']          = (isset($vars['fields']['field_profile_email'])           ? $vars['fields']['field_profile_email']->content : '');
   $vars['office']         = (isset($vars['fields']['field_profile_office'])          ? $vars['fields']['field_profile_office']->content : '');
   $vars['title']          = (isset($vars['fields']['field_profile_title'])           ? $vars['fields']['field_profile_title']->content : '');
   $vars['unit']           = (isset($vars['fields']['field_profile_unit'])            ? $vars['fields']['field_profile_unit']->content : '');
   $vars['website']        = (isset($vars['fields']['field_profile_website'])         ? $vars['fields']['field_profile_website']->content : '');
+  $vars['tags']        = (isset($vars['fields']['field_tags'])                    ? $vars['fields']['field_tags']->content : '');
   $vars['align']          = (isset($vars['fields']['field_profile_align_names'])     ? TRUE : FALSE);
   $vars['custom_fields']  = (isset($vars['fields']['field_profile_custom'])          ? $vars['fields']['field_profile_custom']->content : '');
   

--- a/profiles/ug/themes/ug/ug_theme/templates/views-view-fields--pp6.tpl.php
+++ b/profiles/ug/themes/ug/ug_theme/templates/views-view-fields--pp6.tpl.php
@@ -86,6 +86,12 @@
 		        <?php print $office; ?>
 		      </p>
 		    <?php endif; ?>
+		    <?php if ($tags): ?>
+		      <p>
+		        <?php print t("<strong>@label:</strong>", array('@label' => 'Keywords')); ?>
+		        <?php print $tags; ?>
+		      </p>
+		    <?php endif; ?>
 		    <?php if ($summary): ?>
 		      <p>
 		        <?php print $summary; ?>


### PR DESCRIPTION
# Changes
- Allows site managers to add keywords as a visible field on PP6 custom view using the in-place editor. 
- Displays websites on a single line on PP6 (to be consistent with the keyword display)

# Note
By default, the keyword field does not show, so existing sites should see no visible change from this update until the site manager adds the field. Once enabled, Keywords should appear below Office with a comma-separated field.
