### PR TITLE
Upgrade ckeditor module library (fixes SA-CONTRIB-2020-007)

### DIFF
--- a/profiles/ug/drupal-org.make
+++ b/profiles/ug/drupal-org.make
@@ -23,7 +23,7 @@ projects[captcha][version] = "1.5"
 
 projects[cck][version] = "3.0-alpha3"
 
-projects[ckeditor][version] = "1.18"
+projects[ckeditor][version] = "1.19"
 
 projects[ckeditor_link][version] = "2.4"
 

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.ckeditor_profile.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.ckeditor_profile.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * ug_wysiwyg.features.ckeditor_profile.inc
@@ -101,8 +102,8 @@ function ug_wysiwyg_ckeditor_profile_defaults() {
     'CKEditor Global Profile' => array(
       'name' => 'CKEditor Global Profile',
       'settings' => array(
-        'skin' => 'moono',
-        'ckeditor_path' => '//cdn.ckeditor.com/4.4.3/full-all',
+        'skin' => 'moono-lisa',
+        'ckeditor_path' => '//cdn.ckeditor.com/4.14.0/full-all',
         'ckeditor_local_path' => '',
         'ckeditor_plugins_path' => '%m/plugins',
         'ckeditor_plugins_local_path' => '',

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.filter.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * ug_wysiwyg.features.filter.inc

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * ug_wysiwyg.features.inc

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.user_permission.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.features.user_permission.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * ug_wysiwyg.features.user_permission.inc

--- a/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.strongarm.inc
+++ b/profiles/ug/modules/ug/ug_wysiwyg/ug_wysiwyg.strongarm.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * ug_wysiwyg.strongarm.inc

--- a/sites/all/modules/ckeditor/CHANGELOG.txt
+++ b/sites/all/modules/ckeditor/CHANGELOG.txt
@@ -1,6 +1,50 @@
 7.x-1.x-dev
 Development snapshot
 
+2020-03-17
+New stable release: 7.x-1.19
+
+[#2349885] by hass, Dieter Geiling: Add config.smiley_path for relative image urls
+[#2993053] by stefan.korn: DocBlock missing for hook_user_presave()
+[#2211217] by bwaindwain, gifad: Using "theme css", CKEditor fails to translate URI to valid URL
+[#172229] by vokiel: Update CKEditor to 4.14.0
+[#169464] by vokiel: Fix (remove) the eval() usage inside JavaScript files.
+[#2679179] by Dave Reid, ron_s: CKEditor uses separate cache-busting query string from Drupal's
+[#2795603] by hgoto: drush ckeditor-download command raises warning with undefined offset
+[#2947109] by jstoller: New default CKEditor skin not recognized
+[#2898012] bump CKEditor to 4.9.2
+[#2790539] by Johnny vd Laar: prepare callback is optional, ckeditor_filter_xss causes notices
+
+2017-06-26
+New stable release: 7.x-1.18
+
+[#2463187] by Devin Carlson: Allow plugins to specify custom paths for button icons
+[#2299617] by ben.kyriakou: IMCE browser in CKEditor plugin doesn't respect current language
+[#1330794] by m4olivei, bwaindwain, ConfuciusDa1st, fearlsgroove: Use theme css in sub-theme does not include base theme
+[#2886073] by anrikun: Mistake in feature dependencies
+[#2644124] by drclaw: Some CKEditor plugins buttons don't appear in the Drag & Drop toolbar wizard
+[#2540528] by neerajsingh: In filemanager.config.php, Building $baseDir
+[#2705773] by japerry: ckeditor missing the 'prepare callback' from input filters
+[#2745809] by alvar0hurtad0: Add some tests to avoid failed testing of all patches
+
+2015-11-30
+New stable release: 7.x-1.17
+
+[#2550535] by jcisio, donquixote: $plugin_settings['active'] is messing with features
+[#2574253] by karenann: User specific "Default state" setting is not obeyed
+[#2514938] by themic8, jcisio: Use the latest version from CDN
+[#2542566] by jcisio: remove leftover icon.gif
+[#2542566] by bneil, srjosh, jcisio: Remove Media integration
+[#2437749] by Perignon, david.gil, jcisio: Infinity bucle in some cases in ckeditor_file_download
+[#2463461] by Luukyb: Cleanup .gitignore file from git
+[#1154730] by Sutharsan: CKEditor not following body rows setting Drupal 7
+[#2292575] by Hai-Nam Nguyen: mistakenly added a new line
+[#2292575] by Angry Dan: Naming of mediaembed plugin is confusing
+[#2323149] by kaare: ckeditor.admin.css: url() for tick.png and delete.png must point to ../images/
+[#2159403] by das-peter, aDarkling, Devin Carlson, wwalc, Angry Dan, brantwynn, agoradesign, micbar, joelpittet, brockfanning, iKb: Make CKEditor plugin system modular and clean
+[#2324383] by eugene.ilyin: Toolbar in Ckeditor profile is not saved: incompatibility with jQuery 1.10
+[#2367913] by yched: Fixed ckeditor_help() issues one uncached locale query on each page.
+
 2014-10-14
 New stable release: 7.x-1.16
 

--- a/sites/all/modules/ckeditor/ckeditor.config.js
+++ b/sites/all/modules/ckeditor/ckeditor.config.js
@@ -28,6 +28,9 @@ CKEDITOR.editorConfig = function(config) {
   // config.protectedSource.push(/<code>[\s\S]*?<\/code>/gi);
   config.extraPlugins = '';
 
+  // Insert all Smiley image paths as relative or they may fail on SSL pages.
+  config.smiley_path = window.CKEDITOR_BASEPATH + 'plugins/smiley/images/';
+
   /*
     * Append here extra CSS rules that should be applied into the editing area.
     * Example:

--- a/sites/all/modules/ckeditor/ckeditor.info
+++ b/sites/all/modules/ckeditor/ckeditor.info
@@ -5,9 +5,8 @@ package     = User interface
 configure   = admin/config/content/ckeditor
 
 files[] = tests/ckeditor.test
-; Information added by Drupal.org packaging script on 2017-06-26
-version = "7.x-1.18"
+; Information added by Drupal.org packaging script on 2020-03-17
+version = "7.x-1.19"
 core = "7.x"
 project = "ckeditor"
-datestamp = "1498506247"
-
+datestamp = "1584474894"

--- a/sites/all/modules/ckeditor/ckeditor.module
+++ b/sites/all/modules/ckeditor/ckeditor.module
@@ -41,7 +41,7 @@ define('CKEDITOR_FORCE_SIMPLE_TOOLBAR_NAME', 'DrupalBasic');
 define('CKEDITOR_ENTERMODE_P', 1);
 define('CKEDITOR_ENTERMODE_BR', 2);
 define('CKEDITOR_ENTERMODE_DIV', 3);
-define('CKEDITOR_LATEST', '4.5.4');
+define('CKEDITOR_LATEST', '4.14.0');
 
 global $_ckeditor_configuration;
 global $_ckeditor_ids;

--- a/sites/all/modules/ckeditor/includes/ckeditor.admin.js
+++ b/sites/all/modules/ckeditor/includes/ckeditor.admin.js
@@ -92,8 +92,12 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
     });
     $("#input-formats :checkbox:eq(0)").trigger('change');
 
-    $(".cke_load_toolbar").click(function() {
-      var buttons = eval('Drupal.settings.'+$(this).attr("id"));
+    $(".cke_load_toolbar", "#ckeditor-admin-profile-form").click(function() {
+      var id = $(this).attr("id").replace(/[^\w]/g, '');
+      if (typeof(Drupal.settings[id]) == 'undefined') {
+        return false;
+      }
+      var buttons = Drupal.settings[id];
       var text = "[\n";
       for(i in buttons) {
         if (typeof buttons[i] == 'string'){

--- a/sites/all/modules/ckeditor/includes/ckeditor.drush.inc
+++ b/sites/all/modules/ckeditor/includes/ckeditor.drush.inc
@@ -43,7 +43,7 @@ function ckeditor_drush_command() {
  */
 function ckeditor_drush_download() {
   $args = func_get_args();
-  if ($args[0]) {
+  if (!empty($args[0])) {
     $path = $args[0];
   }
   else {

--- a/sites/all/modules/ckeditor/includes/ckeditor.lib.inc
+++ b/sites/all/modules/ckeditor/includes/ckeditor.lib.inc
@@ -177,12 +177,16 @@ function ckeditor_load_skin_options() {
       closedir($dh);
     }
   }
-  //oops, we have no information about skins, let's use only default
-  if (empty($arr)) {
-    $arr = array(
-      'moono' => 'Moono',
-      'kama' => 'Kama'
-    );
+
+  // If we have no information about skins, use the default for this version.
+  if (!$arr) {
+    $version = explode('.', ckeditor_get_version());
+    if ($version[0] == 3) {
+      $arr = array('kama' => 'Kama');
+    }
+    elseif ($version[0] == 4) {
+      $arr = ($version[1] <= 5) ? array('moono' => 'Moono') : array('moono-lisa' => 'Moono-lisa');
+    }
   }
   asort($arr);
 
@@ -195,15 +199,25 @@ function ckeditor_load_skin_options() {
  * @return string
  */
 function ckeditor_default_skin() {
-  $skin_options = ckeditor_load_skin_options();
-  if (array_key_exists('moono', $skin_options)) {
-    return 'moono';
+  // If there is no available list then bail.
+  if (!$skin_options = ckeditor_load_skin_options()) {
+    return '';
   }
-  if (array_key_exists('kama', $skin_options)) {
-    return 'kama';
+
+  // Default skins in descending order
+  $defaults = array(
+    'moono-lisa' => 'Moono-lisa',
+    'moono' => 'Moono',
+    'kama' => 'Kama'
+  );
+
+  // If there is more than one skin to choose from, use the most current
+  // default.
+  if ($skin_options && ($default = array_intersect_key($defaults, $skin_options))) {
+    return key($default);
   }
-  reset($skin_options);
-  //if any default theme not exists select first from the list
+
+  // If there are no defaults, or only one skin, select the first from the list.
   return key($skin_options);
 }
 
@@ -1084,11 +1098,21 @@ function _ckeditor_add_css_from_theme($current_theme, &$css_files) {
     $color_paths = variable_get('color_' . $current_theme . '_stylesheets', array());
     if (defined('LANGUAGE_RTL') && $language->direction == LANGUAGE_RTL) {
       if (!empty($color_paths[1])) {
-        $css_files[] = $host . $color_paths[1] . $query_string;
+        if (substr($color_paths[0], 0, 9) == 'public://') {
+          $css_files[] = file_create_url($color_paths[1]) . $query_string;
+        }
+        else {
+          $css_files[] = $host . $color_paths[1] . $query_string;
+        }
       }
     }
     elseif (!empty($color_paths[0])) {
-      $css_files[] = $host . $color_paths[0] . $query_string;
+      if (substr($color_paths[0], 0, 9) == 'public://') {
+        $css_files[] = file_create_url($color_paths[0]) . $query_string;
+      }
+      else {
+        $css_files[] = $host . $color_paths[0] . $query_string;
+      }
     }
   }
   else {
@@ -1302,6 +1326,9 @@ function ckeditor_load_by_field($field, $format, $show_toggle = TRUE, $add_field
     elseif (!empty($field["#language"]) && $field["#language"] != LANGUAGE_NONE) {
       drupal_add_js(array('ckeditor' => array('scayt_language' => ckeditor_scayt_langcode($field["#language"]))), 'setting');
     }
+
+    // Pass Drupal's JS cache-busting string via settings along to CKEditor.
+    drupal_add_js(array('ckeditor' => array('timestamp' => variable_get('css_js_query_string', '0'))), 'setting');
 
     // Remember extra information and reuse it during "Preview"
     $processed_ids[$field['#id']]['suffix'] = $suffix;

--- a/sites/all/modules/ckeditor/includes/ckeditor.page.inc
+++ b/sites/all/modules/ckeditor/includes/ckeditor.page.inc
@@ -286,7 +286,7 @@ function ckeditor_filter_xss() {
       }
       continue;
     }
-    if (function_exists($filters[$name]['prepare callback'])) {
+    if (isset($filters[$name]['prepare callback']) && function_exists($filters[$name]['prepare callback'])) {
       $text = $filters[$name]['prepare callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);
     }
     $text = $filters[$name]['process callback']($text, $format_filters[$name], $format, '', TRUE, $cache_id);

--- a/sites/all/modules/ckeditor/includes/ckeditor.user.inc
+++ b/sites/all/modules/ckeditor/includes/ckeditor.user.inc
@@ -121,6 +121,9 @@ function ckeditor_user_customize_form_validate(&$form, &$form_state) {
   }
 }
 
+/**
+ * Implements hook_user_presave().
+ */
 function ckeditor_user_presave(&$edit, $account, $category) {
   if (user_access('customize ckeditor')) {
     module_load_include('inc', 'ckeditor', 'includes/ckeditor.lib');

--- a/sites/all/modules/ckeditor/includes/jqueryUI/sort.js
+++ b/sites/all/modules/ckeditor/includes/jqueryUI/sort.js
@@ -76,18 +76,18 @@ jQuery(document).ready(function() {
         jQuery("li.sortableItem").mouseout(function(){
             jQuery(".sortableList").sortable("enable");
         });
-    }
+    };
 
     Drupal.ckeditorToolbarReload = function() {
         jQuery(".sortableList").sortable('destroy');
         jQuery(".sortableRow").sortable('destroy');
         jQuery("li.sortableItem").unbind();
         Drupal.ckeditorToolbaInit();
-    }
+    };
 
     Drupal.ckeditorToolbarUsedRender = function() {
         var toolbar = jQuery('#edit-toolbar').val();
-        toolbar = eval(toolbar);
+        toolbar = Drupal.ckeditorToolbarToArray(toolbar);
         var html = '<div class="sortableListDiv"><span class="sortableListSpan"><ul class="sortableRow">';
         var group = false;
 
@@ -115,13 +115,13 @@ jQuery(document).ready(function() {
         }
         html += '</ul></span></div>';
         jQuery('#groupLayout').empty().append(html);
-    }
+    };
 
     Drupal.ckeditorToolbarAllRender = function() {
         var toolbarUsed = jQuery('#edit-toolbar').val();
         var toolbarAll = Drupal.settings.cke_toolbar_buttons_all;
 
-        var htmlArray = new Array();
+        var htmlArray = [];
         var html = '';
 
         for (var i in toolbarAll) {
@@ -144,6 +144,17 @@ jQuery(document).ready(function() {
             html += '<div class="sortableListDiv"><span class="sortableListSpan"><ul class="sortableRow">' + htmlArray[j] + '</ul></span></div>';
         }
         jQuery('#allButtons').empty().append(html);
+    };
+
+    if (typeof(Drupal.ckeditorToolbarToArray) == 'undefined') {
+        Drupal.ckeditorToolbarToArray = function (toolbar) {
+            toolbar = toolbar.replace(/\r?\n|\r/gmi, '')
+                .replace(/\s/gmi, '')
+                .replace(/([a-zA-Z0-9]+?):/g, '"$1":')
+                .replace(/'/g, '"');
+
+            return JSON.parse(toolbar);
+        };
     }
 
     Drupal.ckeditorToolbaInit();


### PR DESCRIPTION
Update the Drupal ckeditor module to 7.x-1.19 and update the ckeditor library to 4.14.0. This fixes [SA-CONTRIB-2020-007](https://www.drupal.org/sa-contrib-2020-007) and [SA-CORE-2020-001](https://www.drupal.org/sa-core-2020-001).

The previous default CKEditor skin (moono) has been replaced by a new skin (moono-lisa) which looks slightly different but has the same functionality. The ug_wysiwyg feature has been updated to use the new skin by default. Sites that override the ug_wysiwyg feature module will need to be updated to use the new default skin (manually or by reverting the ug_wysiwyg feature).

In the default configuration, the CKEditor library is loaded from the CDN. The previous version of the ug_wysiwyg feature referenced the 4.4.3 version of the library. The default configuration continues to use the CDN, but now references version 4.14.0 of the library. Sites that override the ug_wysiwyg feature module will need to be updated to use the new library version (manually or by reverting the feature).

Note that SA-CORE-2020-001 specifically targets Drupal 8, but notes that Drupal 7 users should upgrade the CKEditor library to the latest version. This update implements that recommendation.

