### PR TITLE
Style updates

### DIFF
--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -525,6 +525,34 @@ Base Styles
       border-color: #9B1E16;
     }
 
+  /*--------------------------------
+  Responsive Video Embed
+  --------------------------------**/
+  .embed-responsive-4by3 {
+    padding-bottom: 75% !important;
+    }
+    .embed-responsive-16by9 {
+    padding-bottom: 56.25% !important;
+    }
+    .embed-responsive {
+    position: relative;
+    display: block;
+    height: 0;
+    padding: 0;
+    overflow: hidden;
+    }
+    .embed-responsive .embed-responsive-item, 
+    .embed-responsive embed, .embed-responsive iframe, 
+    .embed-responsive object, .embed-responsive video {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    }
+
   /*---------------------
   Pagination
   ---------------------**/

--- a/profiles/ug/themes/ug/ug_theme/css/base.css
+++ b/profiles/ug/themes/ug/ug_theme/css/base.css
@@ -51,10 +51,18 @@ Base Styles
     margin-top: 0;
   }
 
+
+  @media (min-width: 768px) {
+    .lead {
+        font-size: 21px !important;
+    }
+  }
+
   /*---------------------
   Links
   ---------------------**/
-  a{
+  a,
+  a h1, a h2, a h3, a h4, a h5, a h6 {
       color: #2174BB; 
       /* WCAG 2.0 AA on #EEEEEE, #F5F5F5, #FFFFFF */
   }

--- a/profiles/ug/themes/ug/ug_theme/css/layout.css
+++ b/profiles/ug/themes/ug/ug_theme/css/layout.css
@@ -126,3 +126,218 @@
     .panel-panel .panel-pane {
       margin-bottom: 2em;
     }
+
+  /*---------------------
+   Spacing classes
+  ---------------------**/
+
+  .mb-10 {
+    margin-bottom: 10px !important;
+  }
+  .mt-10 {
+    margin-top: 10px !important;
+  }
+  .ml-10 {
+    margin-left: 10px !important;
+  }
+  .mr-10 {
+    margin-right: 10px !important;
+  }
+  .mx-10 {
+    margin-left: 10px !important;
+    margin-right: 10px !important;
+  }
+  .my-10 {
+    margin-bottom: 10px !important;
+    margin-top: 10px !important;
+  }
+  .m-10 {
+    margin-bottom: 10px !important;
+    margin-left: 10px !important;
+    margin-right: 10px !important;
+    margin-top: 10px !important;
+  }
+  .pb-10 {
+    padding-bottom: 10px !important;
+  }
+  .pt-10 {
+    padding-top: 10px !important;
+  }
+  .pl-10 {
+    padding-left: 10px !important;
+  }
+  .pr-10 {
+    padding-right: 10px !important;
+  }
+  .px-10 {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+  }
+  .py-10 {
+    padding-bottom: 10px !important;
+    padding-top: 10px !important;
+  }
+  .p-10 {
+    padding-bottom: 10px !important;
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+    padding-top: 10px !important;
+  }
+  .mb-15 {
+    margin-bottom: 15px !important;
+  }
+  .mt-15 {
+    margin-top: 15px !important;
+  }
+  .ml-15 {
+    margin-left: 15px !important;
+  }
+  .mr-15 {
+    margin-right: 15px !important;
+  }
+  .mx-15 {
+    margin-left: 15px !important;
+    margin-right: 15px !important;
+  }
+  .my-15 {
+    margin-bottom: 15px !important;
+    margin-top: 15px !important;
+  }
+  .m-15 {
+    margin-bottom: 15px !important;
+    margin-left: 15px !important;
+    margin-right: 15px !important;
+    margin-top: 15px !important;
+  }
+  .pb-15 {
+    padding-bottom: 15px !important;
+  }
+  .pt-15 {
+    padding-top: 15px !important;
+  }
+  .pl-15 {
+    padding-left: 15px !important;
+  }
+  .pr-15 {
+    padding-right: 15px !important;
+  }
+  .px-15 {
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
+  .py-15 {
+    padding-bottom: 15px !important;
+    padding-top: 15px !important;
+  }
+  .p-15 {
+    padding-bottom: 15px !important;
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+    padding-top: 15px !important;
+  }
+
+  .mb-20 {
+    margin-bottom: 20px !important;
+  }
+  .mt-20 {
+    margin-top: 20px !important;
+  }
+  .ml-20 {
+    margin-left: 20px !important;
+  }
+  .mr-20 {
+    margin-right: 20px !important;
+  }
+  .mx-20 {
+    margin-left: 20px !important;
+    margin-right: 20px !important;
+  }
+  .my-20 {
+    margin-bottom: 20px !important;
+    margin-top: 20px !important;
+  }
+  .m-20 {
+    margin-bottom: 20px !important;
+    margin-left: 20px !important;
+    margin-right: 20px !important;
+    margin-top: 20px !important;
+  }
+  .pb-20 {
+    padding-bottom: 20px !important;
+  }
+  .pt-20 {
+    padding-top: 20px !important;
+  }
+  .pl-20 {
+    padding-left: 20px !important;
+  }
+  .pr-20 {
+    padding-right: 20px !important;
+  }
+  .px-20 {
+    padding-left: 20px !important;
+    padding-right: 20px !important;
+  }
+  .py-20 {
+    padding-bottom: 20px !important;
+    padding-top: 20px !important;
+  }
+  .p-20 {
+    padding-bottom: 20px !important;
+    padding-left: 20px !important;
+    padding-right: 20px !important;
+    padding-top: 20px !important;
+  }
+
+  .mb-40 {
+    margin-bottom: 40px !important;
+  }
+  .mt-40 {
+    margin-top: 40px !important;
+  }
+  .ml-40 {
+    margin-left: 40px !important;
+  }
+  .mr-40 {
+    margin-right: 40px !important;
+  }
+  .mx-40 {
+    margin-left: 40px !important;
+    margin-right: 40px !important;
+  }
+  .my-40 {
+    margin-bottom: 40px !important;
+    margin-top: 40px !important;
+  }
+  .m-40 {
+    margin-bottom: 40px !important;
+    margin-left: 40px !important;
+    margin-right: 40px !important;
+    margin-top: 40px !important;
+  }
+  .pb-40 {
+    padding-bottom: 40px !important;
+  }
+  .pt-40 {
+    padding-top: 40px !important;
+  }
+  .pl-40 {
+    padding-left: 40px !important;
+  }
+  .pr-40 {
+    padding-right: 40px !important;
+  }
+  .px-40 {
+    padding-left: 40px !important;
+    padding-right: 40px !important;
+  }
+  .py-40 {
+    padding-bottom: 40px !important;
+    padding-top: 40px !important;
+  }
+  .p-40 {
+    padding-bottom: 40px !important;
+    padding-left: 40px !important;
+    padding-right: 40px !important;
+    padding-top: 40px !important;
+  }


### PR DESCRIPTION
- Ensure linked headings use the standard blue link colour
- Ensure .lead class uses Bootstrap sizes
- Add responsive video embed classes
- Add spacer classes that allow users to assign padding and margins of 10px, 15px, 20px, and 40px. 

# Using the Responsive Video Embed classes
```
<!-- 16:9 aspect ratio -->
<div class="embed-responsive embed-responsive-16by9">
  <iframe class="embed-responsive-item" src="..."></iframe>
</div>

<!-- 4:3 aspect ratio -->
<div class="embed-responsive embed-responsive-4by3">
  <iframe class="embed-responsive-item" src="..."></iframe>
</div>
```

# Using the Spacer Classes
For the spacer classes, the naming format is {property}{sides}-{size}. 

Where {property} is one of:
- m - for classes that set margin
- p - for classes that set padding

Where {sides} is one of:
- t - for classes that set margin-top or padding-top
- b - for classes that set margin-bottom or padding-bottom
- l - for classes that set margin-left or padding-left
- r - for classes that set margin-right or padding-right
- x - for classes that set both *-left and *-right
- y - for classes that set both *-top and *-bottom
- blank - for classes that set a margin or padding on all 4 sides of the element

Where {size} is one of:
- 10 - (by default) for classes that set the margin or padding to 10px
- 15 - (by default) for classes that set the margin or padding to 15px
- 20 - (by default) for classes that set the margin or padding to 20px
- 40 - (by default) for classes that set the margin or padding to 40px

So ```class="mt-40"``` sets the margin of an element to 40px.