### PR TITLE
Update to Drupal 7.97. For more information, see https://www.drupal.org/project/drupal/releases/7.97

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 7.97, 2023-04-21
+-----------------------
+- Fix PHP 5.x regression caused by SA-CORE-2023-005
+
 Drupal 7.96, 2023-04-19
 -----------------------
 - Fixed security issues:

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.96');
+define('VERSION', '7.97');
 
 /**
  * Core API compatibility.

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -2753,7 +2753,7 @@ function file_uri_normalize_dot_segments($uri) {
     if ($target !== FALSE) {
       if (!in_array($scheme, variable_get('file_sa_core_2023_005_schemes', array()))) {
         $class = file_stream_wrapper_get_class($scheme);
-        $is_local = is_subclass_of($class, DrupalLocalStreamWrapper::class);
+        $is_local = is_subclass_of($class, 'DrupalLocalStreamWrapper');
         if ($is_local) {
           $target = str_replace(DIRECTORY_SEPARATOR, '/', $target);
         }

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -4100,7 +4100,7 @@ function system_file_download($uri) {
       if (!in_array($scheme, variable_get('file_sa_core_2023_005_schemes', array()))) {
         if (DIRECTORY_SEPARATOR !== '/') {
           $class = file_stream_wrapper_get_class($scheme);
-          if (is_subclass_of($class, DrupalLocalStreamWrapper::class)) {
+          if (is_subclass_of($class, 'DrupalLocalStreamWrapper')) {
             $target = str_replace(DIRECTORY_SEPARATOR, '/', $target);
           }
         }


### PR DESCRIPTION
"hotfix" release to address a PHP 5.x regression caused by SA-CORE-2023-005.