### PR TITLE
Add Drupal Longterm Support module via Pantheon

### DIFF
--- a/.github/update_tag1_d7es.sh
+++ b/.github/update_tag1_d7es.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+main() {
+  # Variables
+  local MODULE_NAME="tag1_d7es"
+  local PANTHEON_UPSTREAM_DIR="modules/pantheon/$MODULE_NAME"
+  local PR_BASE_BRANCH="default"
+  local CURRENT_VERSION
+  local LATEST_VERSION
+  local TEMP_BRANCH
+  TEMP_BRANCH="update-$MODULE_NAME-$(date +%Y%m%d%H%M%S)"
+
+  # With these credentials, commits will be pushed to 'master' and available on
+  # the upstream immediately.
+  local GIT_USER="bot@getpantheon.com"
+  local GIT_NAME="Pantheon Automation"
+
+  local RELEASE_HISTORY_URL="https://updates.drupal.org/release-history/${MODULE_NAME}/7.x"
+  LATEST_VERSION=$(curl -s "$RELEASE_HISTORY_URL" \
+    | grep -oE '<version>[0-9a-zA-Z\.\-]+' \
+    | sed 's/<version>//' \
+    | grep -vE '(-rc|-beta|-alpha)' \
+    | sort -V | tail -n 1
+  )
+
+  CURRENT_VERSION=$(grep '^version' "${PANTHEON_UPSTREAM_DIR}/tag1_d7es.info" \
+    | awk -F' = ' '{print $2}' | tr -d '"'
+  )
+
+  echo "Current: ${CURRENT_VERSION}"
+  echo "Latest: ${LATEST_VERSION}"
+
+  if [ "$LATEST_VERSION" == "$CURRENT_VERSION" ]; then
+    echo "Already up to date."
+    exit 0
+  fi
+
+  local PR_TITLE="Update $MODULE_NAME to version $LATEST_VERSION"
+  local PR_EXISTS
+  PR_EXISTS=$(gh pr list --state open --search "$LATEST_VERSION" --json title \
+    | jq --arg pr_title "$PR_TITLE" '.[] | select(.title | contains($pr_title))'
+  )
+
+  if [ -n "$PR_EXISTS" ]; then
+    echo "A PR for version $LATEST_VERSION already exists. Skipping PR creation."
+    exit 0
+  fi
+
+  git checkout -b "$TEMP_BRANCH"
+
+  local DRUPAL_ORG_FTP_GZ_URL="https://ftp.drupal.org/files/projects/$MODULE_NAME-$LATEST_VERSION.tar.gz"
+  wget -qO- "$DRUPAL_ORG_FTP_GZ_URL" | tar -xz -C /tmp
+
+  rsync -ar --delete "/tmp/$MODULE_NAME/" "$PANTHEON_UPSTREAM_DIR/"
+  rm -rf "$PANTHEON_UPSTREAM_DIR/.github"
+  rm -f "$PANTHEON_UPSTREAM_DIR/.gitlab-ci.yml"
+  rm -rf "$PANTHEON_UPSTREAM_DIR/tests"
+
+  git config user.email "${GIT_USER}"
+  git config user.name "${GIT_NAME}"
+
+  git add "$PANTHEON_UPSTREAM_DIR"
+  git commit -m "Update $MODULE_NAME to version $LATEST_VERSION"
+  git push origin "$TEMP_BRANCH"
+
+  local PR_BODY="Updates the $MODULE_NAME module to version $LATEST_VERSION."
+  gh pr create --title "$PR_TITLE" \
+      --body "$PR_BODY" \
+      --head "$TEMP_BRANCH" \
+      --base "$PR_BASE_BRANCH"
+}
+
+main

--- a/.github/workflows/update_tag1_d7es.yml
+++ b/.github/workflows/update_tag1_d7es.yml
@@ -1,0 +1,24 @@
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq wget curl
+      - name: Check and Update Module
+        run: .github/update_tag1_d7es.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 7.103, 2024-12-04
+------------------------
+- So Long, and Thanks for All the Fish
+
 Drupal 7.102, 2024-11-20
 ------------------------
 - Fixed security issues:
@@ -5,7 +9,7 @@ Drupal 7.102, 2024-11-20
    - SA-CORE-2024-008
 
 Drupal 7.101, 2024-06-05
------------------------
+------------------------
 - Various security improvements
 - Various bug fixes, optimizations and improvements
 

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.102');
+define('VERSION', '7.103');
 
 /**
  * Core API compatibility.
@@ -457,9 +457,6 @@ abstract class DrupalCacheArray implements ArrayAccess {
     if ($this->bin == 'cache_form' && !variable_get('drupal_cache_array_persist_cache_form', FALSE)) {
       return;
     }
-    if (!is_array($this->keysToPersist)) {
-      throw new UnexpectedValueException();
-    }
     $data = array();
     foreach ($this->keysToPersist as $offset => $persist) {
       if ($persist) {
@@ -732,8 +729,8 @@ function drupal_environment_initialize() {
 /**
  * Validates that a hostname (for example $_SERVER['HTTP_HOST']) is safe.
  *
- * @return
- *  TRUE if only containing valid characters, or FALSE otherwise.
+ * @return bool
+ *   TRUE if it only contains valid characters, FALSE otherwise.
  */
 function drupal_valid_http_host($host) {
   // Limit the length of the host name to 1000 bytes to prevent DoS attacks with
@@ -769,6 +766,12 @@ function drupal_settings_initialize() {
   if (file_exists(DRUPAL_ROOT . '/' . conf_path() . '/settings.php')) {
     include_once DRUPAL_ROOT . '/' . conf_path() . '/settings.php';
   }
+  
+  // Auth Tag1 D7ES module on Pantheon
+  if (getenv('PANTHEON_D7ES_API_KEY')) {
+    $conf['tag1_d7es_billing_email'] = getenv('PANTHEON_D7ES_API_KEY');
+  }
+
   $is_https = drupal_is_https();
 
   // Load environmental config, if present.
@@ -840,8 +843,8 @@ function drupal_settings_initialize() {
     // Otherwise use $base_url as session name, without the protocol
     // to use the same session identifiers across HTTP and HTTPS.
     list( , $session_name) = explode('://', $base_url, 2);
-    // HTTP_HOST can be modified by a visitor, but we already sanitized it
-    // in drupal_settings_initialize().
+    // HTTP_HOST can be modified by a visitor, but we already sanitized it in
+    // drupal_environment_initialize().
     if (!empty($_SERVER['HTTP_HOST'])) {
       $cookie_domain = _drupal_get_cookie_domain($_SERVER['HTTP_HOST']);
     }
@@ -2757,6 +2760,18 @@ function _drupal_bootstrap_configuration() {
   // Initialize the configuration, including variables from settings.php.
   drupal_settings_initialize();
 
+  // Check trusted HTTP Host headers to protect against header attacks.
+  if (PHP_SAPI !== 'cli') {
+    $host_patterns = variable_get('trusted_host_patterns', array());
+    if (!empty($host_patterns)) {
+      if (!drupal_check_trusted_hosts($_SERVER['HTTP_HOST'], $host_patterns)) {
+        header($_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request');
+        print 'The provided host name is not valid for this server.';
+        exit;
+      }
+    }
+  }
+
   // Sanitize unsafe keys from the request.
   DrupalRequestSanitizer::sanitize();
 }
@@ -4000,6 +4015,36 @@ function drupal_clear_opcode_cache($filepath) {
     // @see http://php.net/apc-delete-file
     @apc_delete_file($filepath);
   }
+}
+
+/**
+ * Checks trusted HTTP Host headers to protect against header injection attacks.
+ *
+ * @param string|null $host
+ *   The host name.
+ * @param array $host_patterns
+ *   The array of trusted host patterns.
+ *
+ * @return bool
+ *   TRUE if the host is trusted, FALSE otherwise.
+ */
+function drupal_check_trusted_hosts($host, array $host_patterns) {
+  if (!empty($host) && !empty($host_patterns)) {
+    // Trim and remove the port number from host; host is lowercase as per
+    // RFC 952/2181.
+    $host = strtolower(preg_replace('/:\d+$/', '', trim($host)));
+
+    foreach ($host_patterns as $pattern) {
+      $pattern = sprintf('{%s}i', $pattern);
+      if (preg_match($pattern, $host)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2967,7 +2967,11 @@ function drupal_set_time_limit($time_limit) {
  *   The path to the requested item or an empty string if the item is not found.
  */
 function drupal_get_path($type, $name) {
-  return dirname(drupal_get_filename($type, $name));
+  if ($filename = drupal_get_filename($type, $name)) {
+    return dirname($filename);
+  }
+
+  return "";
 }
 
 /**

--- a/includes/errors.inc
+++ b/includes/errors.inc
@@ -224,7 +224,7 @@ function _drupal_log_error($error, $fatal = FALSE) {
     if ($fatal) {
       if (error_displayable($error)) {
         // When called from JavaScript, simply output the error message.
-        print t('%type: !message in %function (line %line of %file).', $error);
+        print t('%type: !message in %function (line %line of %file).', _drupal_strip_error_file_path($error));
       }
       exit;
     }
@@ -242,7 +242,7 @@ function _drupal_log_error($error, $fatal = FALSE) {
         $class = 'status';
       }
 
-      drupal_set_message(t('%type: !message in %function (line %line of %file).', $error), $class);
+      drupal_set_message(t('%type: !message in %function (line %line of %file).', _drupal_strip_error_file_path($error)), $class);
     }
 
     if ($fatal) {
@@ -290,4 +290,29 @@ function _drupal_get_last_caller($backtrace) {
     $call['function'] = 'main()';
   }
   return $call;
+}
+
+/**
+ * Strip full path information from error details.
+ *
+ * @param $error
+ *   An array with the following keys: %type, !message, %function, %file, %line
+ *   and severity_level.
+ *
+ * @return
+ *   An array with the same keys as the $error param but with full paths
+ *   stripped from the %file element
+ */
+function _drupal_strip_error_file_path($error) {
+  if (!empty($error['%file'])) {
+    if (($drupal_root_position = strpos($error['%file'], DRUPAL_ROOT)) === 0) {
+      $root_length = strlen(DRUPAL_ROOT);
+      $error['%file'] = substr($error['%file'], $root_length + 1);
+    }
+    elseif ($drupal_root_position !== FALSE) {
+      // As a fallback, make sure DRUPAL_ROOT's value is not in the path.
+      $error['%file'] = str_replace(DRUPAL_ROOT, 'DRUPAL_ROOT', $error['%file']);
+    }
+  }
+  return $error;
 }

--- a/includes/mail.inc
+++ b/includes/mail.inc
@@ -624,7 +624,7 @@ function drupal_mail_format_display_name($string) {
  */
 function _drupal_wrap_mail_line(&$line, $key, $values) {
   // Use soft-breaks only for purely quoted or unindented text.
-  $line = wordwrap($line, 77 - $values['length'], $values['soft'] ? " \n" : "\n");
+  $line = wordwrap($line, 77 - $values['length'], $values['soft'] ? "  \n" : "\n");
   // Break really long words at the maximum width allowed.
   $line = wordwrap($line, 996 - $values['length'], $values['soft'] ? " \n" : "\n", TRUE);
 }

--- a/includes/utility.inc
+++ b/includes/utility.inc
@@ -26,7 +26,7 @@ function drupal_var_export($var, $prefix = '') {
       // Don't export keys if the array is non associative.
       $export_keys = array_values($var) != $var;
       foreach ($var as $key => $value) {
-        $output .= '  ' . ($export_keys ? drupal_var_export($key) . ' => ' : '') . drupal_var_export($value, '  ', FALSE) . ",\n";
+        $output .= '  ' . ($export_keys ? drupal_var_export($key) . ' => ' : '') . drupal_var_export($value, '  ') . ",\n";
       }
       $output .= ')';
     }
@@ -35,7 +35,6 @@ function drupal_var_export($var, $prefix = '') {
     $output = $var ? 'TRUE' : 'FALSE';
   }
   elseif (is_string($var)) {
-    $line_safe_var = str_replace("\n", '\n', $var);
     if (strpos($var, "\n") !== FALSE || strpos($var, "'") !== FALSE) {
       // If the string contains a line break or a single quote, use the
       // double quote export mode. Encode backslash and double quotes and

--- a/modules/field/modules/text/text.test
+++ b/modules/field/modules/text/text.test
@@ -377,6 +377,15 @@ class TextSummaryTestCase extends DrupalWebTestCase {
     // Test text_summary() for different sizes.
     for ($i = 0; $i <= 37; $i++) {
       $this->callTextSummary($text, $expected[$i],    NULL, $i);
+
+      // libxml2 library changed parsing behavior on version 2.9.14. Skip
+      // specific edge-case testing for all further versions.
+      // @see https://gitlab.gnome.org/GNOME/libxml2/-/issues/474
+      // @see https://www.drupal.org/project/drupal/issues/3397882
+      if ($i == 1 && defined('LIBXML_VERSION') && LIBXML_VERSION >= 20914) {
+        continue;
+      }
+
       $this->callTextSummary($text, $expected_lb[$i], 'plain_text', $i);
       $this->callTextSummary($text, $expected_lb[$i], 'filtered_html', $i);
     }

--- a/modules/filter/filter.module
+++ b/modules/filter/filter.module
@@ -1515,14 +1515,26 @@ function _filter_url($text, $filter) {
   // re-split after each task, since all injected HTML tags must be correctly
   // protected before the next task.
   foreach ($tasks as $task => $pattern) {
+    // Store the current text in case any of the preg_* functions fail.
+    $saved_text = $text;
+
     // HTML comments need to be handled separately, as they may contain HTML
     // markup, especially a '>'. Therefore, remove all comment contents and add
     // them back later.
     _filter_url_escape_comments('', TRUE);
     $text = preg_replace_callback('`<!--(.*?)-->`s', '_filter_url_escape_comments', $text);
+    if (preg_last_error()) {
+      $text = $saved_text;
+      continue 1;
+    }
 
     // Split at all tags; ensures that no tags or attributes are processed.
     $chunks = preg_split('/(<.+?>)/is', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+    if (preg_last_error()) {
+      $text = $saved_text;
+      continue 1;
+    }
+
     // PHP ensures that the array consists of alternating delimiters and
     // literals, and begins and ends with a literal (inserting NULL as
     // required). Therefore, the first chunk is always text:
@@ -1539,6 +1551,10 @@ function _filter_url($text, $filter) {
           // If there is a match, inject a link into this chunk via the callback
           // function contained in $task.
           $chunks[$i] = preg_replace_callback($pattern, $task, $chunks[$i]);
+          if (preg_last_error()) {
+            $text = $saved_text;
+            continue 2;
+          }
         }
         // Text chunk is done, so next chunk must be a tag.
         $chunk_type = 'tag';
@@ -1566,6 +1582,10 @@ function _filter_url($text, $filter) {
     // Revert back to the original comment contents
     _filter_url_escape_comments('', FALSE);
     $text = preg_replace_callback('`<!--(.*?)-->`', '_filter_url_escape_comments', $text);
+    if (preg_last_error()) {
+      $text = $saved_text;
+      continue 1;
+    }
   }
 
   return $text;

--- a/modules/filter/filter.test
+++ b/modules/filter/filter.test
@@ -1637,6 +1637,7 @@ www.example.com with a newline in comments -->
    *   comments.
    * - Empty HTML tags (BR, IMG).
    * - Mix of absolute and partial URLs, and e-mail addresses in one content.
+   * - Input that exceeds PCRE backtracking limit.
    */
   function testUrlFilterContent() {
     // Setup dummy filter object.
@@ -1650,6 +1651,16 @@ www.example.com with a newline in comments -->
     $expected = file_get_contents($path . '/filter.url-output.txt');
     $result = _filter_url($input, $filter);
     $this->assertIdentical($result, $expected, 'Complex HTML document was correctly processed.');
+
+    // Case of a small and simple HTML document.
+    $input = $expected = '<p>www.test.com</p>';
+    $result = $this->filterUrlWithPcreErrors($input, $filter);
+    $this->assertIdentical($expected, $result, 'Simple HTML document was left intact when PCRE errors occurred.');
+
+    // Case of a complex HTML document.
+    $input = $expected = file_get_contents($path . '/filter.url-input.txt');
+    $result = $this->filterUrlWithPcreErrors($input, $filter);
+    $this->assertIdentical($expected, $result, 'Complex HTML document was left intact when PCRE errors occurred.');
   }
 
   /**
@@ -1889,6 +1900,28 @@ body {color:red}
    */
   function assertNoNormalized($haystack, $needle, $message = '', $group = 'Other') {
     return $this->assertTrue(strpos(strtolower(decode_entities($haystack)), $needle) === FALSE, $message, $group);
+  }
+
+  /**
+   * Calls filter_url with pcre.backtrack_limit set to 1.
+   *
+   * When PCRE errors occur, _filter_url() returns the input text unchanged.
+   *
+   * @param $input
+   *   Text to pass on to _filter_url().
+   * @param $filter
+   *   Filter to pass on to _filter_url().
+   * @return
+   *   The processed $input.
+   */
+  protected function filterUrlWithPcreErrors($input, $filter) {
+    $pcre_backtrack_limit = ini_get('pcre.backtrack_limit');
+    // Setting this limit to the smallest possible value should cause PCRE
+    // errors and break the various preg_* functions used by _filter_url().
+    ini_set('pcre.backtrack_limit', 1);
+    $result = _filter_url($input, $filter);
+    ini_set('pcre.backtrack_limit', $pcre_backtrack_limit);
+    return $result;
   }
 }
 

--- a/modules/pantheon/tag1_d7es/LICENSE.txt
+++ b/modules/pantheon/tag1_d7es/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/modules/pantheon/tag1_d7es/README.md
+++ b/modules/pantheon/tag1_d7es/README.md
@@ -1,0 +1,52 @@
+# tag1_d7es
+
+Drupal 7 module to support Tag1's D7ES offering.
+
+Installation and use of this module constitutes your acceptance of and agreement
+to be bound by Tag1 Consulting Inc's Terms of Service and Privacy Policy,
+as published at D7ES.Tag1.com.
+
+## Requirements
+* A properly configured [cron job](https://www.drupal.org/docs/7/setting-up-cron/overview)
+* An active customer account created at https://d7es.tag1.com/
+
+## Configuration
+1. Download and enable the module as usual.
+2. Visit the module's configuration page at `/admin/config/system/tag1-d7es` and
+enter the Billing email address used when creating the customer account. You
+will also need to supply one or more email addresses that should be notified of
+available security updates.
+3. Save the form. Status messages will let you know if the site is authenticated
+and sending data successfully.
+
+## How does it work?
+This module will report the following information about your site to the Tag1
+D7ES team:
+
+* the version of Drupal core
+* name and version of contributed modules and themes
+* database type and version
+* PHP version
+* the URL of your website
+* the billing account email address
+* list of email addresses who should be notified when a security update is available
+
+This report is submitted via a cron job a maximum of once per 24 hours.
+
+The full JSON payload sent by your site may be previewed from the module's
+configuration page under the "Debugging" fieldset.
+
+## For extra security
+
+For extra security, you may wish to configure the "Billing email address" and
+"Notification email addresses" outside of the site's database. You can use the
+variables `tag1_d7es_billing_email` and `tag1_d7es_email_addresses` to define
+these values directly in settings.php, or by calling an environment variable.
+
+```php
+// Including value in code.
+$conf['tag1_d7es_billing_email'] = 'my-billing@email.com';
+
+// Sourcing from an environment variable.
+$conf['tag1_d7es_billing_email'] = $_ENV['MY_BILLING_EMAIL_VARIABLE'];
+```

--- a/modules/pantheon/tag1_d7es/includes/uuid.inc
+++ b/modules/pantheon/tag1_d7es/includes/uuid.inc
@@ -1,0 +1,70 @@
+<?php
+// phpcs:ignoreFile
+/**
+ * @file
+ * Enables our module to use UUIDs without the UUID or CTools modules enabled.
+ */
+
+/**
+ * Pattern for detecting a valid UUID.
+ */
+if (!defined('UUID_PATTERN')) {
+  define('UUID_PATTERN', '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}');
+}
+
+/**
+ * Generates a UUID using the Windows internal GUID generator.
+ *
+ * @see http://php.net/com_create_guid
+ */
+function _tag1_d7es_uuid_generate_com() {
+  // Remove {} wrapper and make lower case to keep result consistent.
+  return drupal_strtolower(trim(com_create_guid(), '{}'));
+}
+
+/**
+ * Generates an universally unique identifier using the PECL extension.
+ */
+function _tag1_d7es_uuid_generate_pecl() {
+  $uuid_type = UUID_TYPE_DEFAULT;
+  return uuid_create($uuid_type);
+}
+
+/**
+ * Generates a UUID v4 using PHP code.
+ *
+ * Based on code from @see http://php.net/uniqid#65879 , but corrected.
+ */
+function _tag1_d7es_uuid_generate_php() {
+  // The field names refer to RFC 4122 section 4.1.2.
+  return sprintf('%04x%04x-%04x-4%03x-%04x-%04x%04x%04x',
+    // 32 bits for "time_low".
+    mt_rand(0, 65535), mt_rand(0, 65535),
+    // 16 bits for "time_mid".
+    mt_rand(0, 65535),
+    // 12 bits after the 0100 of (version) 4 for "time_hi_and_version".
+    mt_rand(0, 4095),
+    bindec(substr_replace(sprintf('%016b', mt_rand(0, 65535)), '10', 0, 2)),
+    // 8 bits, the last two of which (positions 6 and 7) are 01, for "clk_seq_hi_res"
+    // (hence, the 2nd hex digit after the 3rd hyphen can only be 1, 5, 9 or d)
+    // 8 bits for "clk_seq_low" 48 bits for "node".
+    mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535)
+  );
+}
+
+// This is wrapped in an if block to avoid conflicts with PECL's uuid_is_valid().
+/**
+ * Check that a string appears to be in the format of a UUID.
+ *
+ * @param $uuid
+ *  The string to test.
+ *
+ * @return
+ *   TRUE if the string is well formed.
+ */
+if (!function_exists('uuid_is_valid')) {
+  function uuid_is_valid($uuid) {
+    return preg_match('/^' . UUID_PATTERN . '$/', $uuid);
+  }
+
+}

--- a/modules/pantheon/tag1_d7es/tag1_d7es.info
+++ b/modules/pantheon/tag1_d7es/tag1_d7es.info
@@ -1,0 +1,18 @@
+name = Tag1 D7ES
+description = Module that communicates with Tag1's D7ES service. <br/>Installation and use of this module constitutes your acceptance of and agreement to be bound by Tag1 Consulting Inc's Terms of Service and Privacy Policy, as published at <a href="https://d7es.tag1.com/">D7ES.Tag1.com</a>.
+core = 7.x
+package = Tag1
+configure = admin/config/system/tag1-d7es
+files[] = tests/tag1_d7es.test
+files[] = tests/tag1_d7es_ctools.test
+files[] = tests/tag1_d7es_admin.test
+files[] = tests/tag1_d7es_admin_ctools.test
+files[] = tests/tag1_d7es_fetch_url.test
+files[] = tests/tag1_d7es_mail.test
+files[] = tests/tag1_d7es_update.test
+
+; Information added by Drupal.org packaging script on 2024-11-27
+version = "7.x-1.1"
+core = "7.x"
+project = "tag1_d7es"
+datestamp = "1732731772"

--- a/modules/pantheon/tag1_d7es/tag1_d7es.install
+++ b/modules/pantheon/tag1_d7es/tag1_d7es.install
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @file
+ * Contains install and update functions for tag1_d7es.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function tag1_d7es_install() {
+  variable_set('tag1_d7es_site_id', tag1_d7es_uuid_generate());
+  if (variable_get('update_fetch_url')) {
+    variable_set('tag1_d7es_original_update_fetch_url', variable_get('update_fetch_url'));
+  }
+  variable_set('tag1_d7es_phone_home', 0);
+  variable_set('tag1_d7es_send_update_emails', 0);
+  drupal_set_message(t('Thank you for installing Tag1 D7ES. Please proceed to the <a href="/admin/config/system/tag1-d7es">configuration page</a> to configure authentication and notifications. Installation and use of this module constitutes your acceptance of and agreement to be bound by Tag1 Consulting Inc\'s Terms of Service and Privacy Policy, as published at D7ES.Tag1.com.'));
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function tag1_d7es_uninstall() {
+  if (variable_get('tag1_d7es_original_update_fetch_url')) {
+    variable_set('update_fetch_url', variable_get('tag1_d7es_original_update_fetch_url'));
+    variable_del('tag1_d7es_original_update_fetch_url');
+  }
+  else {
+    variable_del('update_fetch_url');
+  }
+  variable_del('tag1_d7es_site_id');
+  variable_del('tag1_d7es_phone_home');
+  variable_del('tag1_d7es_billing_email');
+  variable_del('tag1_d7es_email_addresses');
+  variable_del('tag1_d7es_endpoint');
+  variable_del('tag1_d7es_send_update_emails');
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function tag1_d7es_requirements($phase) {
+  $requirements = array();
+
+  // Display reporting status.
+  if ($phase == 'runtime') {
+    $description = '';
+    $last_phone_home = variable_get('tag1_d7es_phone_home');
+    if ($last_phone_home == 0) {
+      $value = t('Never');
+      $description = t('The Tag1 D7ES module has not successfully connected. Please visit the <a href="/admin/config/system/tag1-d7es">configuration page</a> to configure authentication and notifications.');
+      $severity = REQUIREMENT_ERROR;
+    }
+    elseif (is_null(variable_get('tag1_d7es_billing_email')) || is_null(variable_get('tag1_d7es_email_addresses'))) {
+      $value = t('Missing configuration');
+      $description = t('The Tag1 D7ES module is missing key configuration. Please visit the <a href="/admin/config/system/tag1-d7es">configuration page</a> to configure authentication and notifications.');
+      $severity = REQUIREMENT_ERROR;
+    }
+    elseif ($last_phone_home <= REQUEST_TIME - 604800) {
+      $value = t('Last run: %phone-home-last ago.', array(
+        '%phone-home-last' => format_interval(REQUEST_TIME - $last_phone_home),
+      ));
+      $description = t('Last report sent over a week ago. Please check that cron is running successfully.');
+      $severity = REQUIREMENT_WARNING;
+    }
+    else {
+      $value = t('Last run: %phone-home-last ago.', array(
+        '%phone-home-last' => format_interval(REQUEST_TIME - $last_phone_home),
+      ));
+      $severity = REQUIREMENT_OK;
+    }
+
+    $requirements['tag1_d7es'] = array(
+      'title' => 'Tag1 D7ES',
+      'value' => $value,
+      'description' => $description,
+      'severity' => $severity,
+    );
+  }
+
+  return $requirements;
+}
+
+/**
+ * Set update_fetch_url if able.
+ */
+function tag1_d7es_update_7100(&$sandbox) {
+  if (variable_get('update_fetch_url')) {
+    variable_set('tag1_d7es_original_update_fetch_url', variable_get('update_fetch_url'));
+  }
+  if (variable_get('tag1_d7es_phone_home')) {
+    variable_set('update_fetch_url', tag1_d7es_personalize_updates_endpoint());
+  }
+}

--- a/modules/pantheon/tag1_d7es/tag1_d7es.module
+++ b/modules/pantheon/tag1_d7es/tag1_d7es.module
@@ -1,0 +1,897 @@
+<?php
+
+/**
+ * @file
+ * Tag1 D7ES primary module file.
+ *
+ * Installation and use of this module constitutes your acceptance of and
+ * agreement to be bound by Tag1 Consulting Inc's Terms of Service and Privacy
+ * Policy, as published at D7ES.Tag1.com.
+ *
+ * @phpcs:disable SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
+ */
+
+define('TAG1_D7ES_PHONE_HOME_PERIOD', 86400);
+define('TAG1_D7ES_ENDPOINT', 'https://analytics-d7es.tag1.com/d7es');
+define('TAG1_D7ES_PLATFORM_PANTHEON', 'pantheon');
+define('TAG1_D7ES_UPDATES_ENDPOINT', 'https://updates.tag1.com/release-history');
+
+/**
+ * Implements hook_cron().
+ */
+function tag1_d7es_cron() {
+  // Check timing of last update before continuing.
+  if (variable_get('tag1_d7es_phone_home', 0) <= REQUEST_TIME - TAG1_D7ES_PHONE_HOME_PERIOD) {
+    $site_id = variable_get('tag1_d7es_site_id');
+    $billing_email = variable_get('tag1_d7es_billing_email');
+    if (tag1_d7es_preflight($site_id, $billing_email)) {
+      $data = _tag1_d7es_payload($site_id);
+      _tag1_d7es_transmit($billing_email, $data);
+    }
+  }
+}
+
+/**
+ * Run preflight checks on API submission data.
+ *
+ * @param string $site_id
+ *   The Site ID to verify.
+ * @param string $billing_email
+ *   The billing email address to verify.
+ * @param bool $display_messages
+ *   Whether messages should be displayed in addition to being logged.
+ *
+ * @return bool
+ *   Whether the API request should be attempted.
+ */
+function tag1_d7es_preflight($site_id, $billing_email, $display_messages = FALSE) {
+  // Ensure a valid Site ID.
+  if (!tag1_d7es_uuid_is_valid($site_id)) {
+    $config_error = 'Unable to send data because the Site ID is not valid.';
+    $log_message = "$config_error Please visit <a href='/admin/config/system/tag1-d7es'>the configuration page (under advanced settings)</a> to correct it.";
+    watchdog(
+      'tag1_d7es',
+      $log_message,
+      array(),
+      WATCHDOG_ERROR
+    );
+    if ($display_messages) {
+      drupal_set_message($config_error, 'error');
+    }
+    return FALSE;
+  }
+
+  // Ensure the billing email address is provided.
+  if (!$billing_email) {
+    $config_error = 'Unable to send data because the billing email address is not provided.';
+    $message = "$config_error Please visit <a href='/admin/config/system/tag1-d7es'>the configuration page</a> to provide it.";
+    watchdog(
+      'tag1_d7es',
+      $message,
+      array(),
+      WATCHDOG_ERROR
+    );
+    if ($display_messages) {
+      drupal_set_message($config_error, 'error');
+    }
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * Send data to Tag1.
+ *
+ * @param string $billing_email
+ *   The primary billing email address, used for authentication.
+ * @param array $data
+ *   The data payload.
+ * @param bool $display_messages
+ *   Whether messages should be displayed in addition to being logged.
+ * @param string $override_url
+ *   Allows validation against a new endpoint without officially saving it.
+ *
+ * @return bool
+ *   Returns TRUE if the transmission was successful.
+ */
+function _tag1_d7es_transmit($billing_email, $data, $display_messages = FALSE, $override_url = '') {
+  $url = $override_url ?: _tag1_d7es_get_endpoint();
+  $auth_token = base64_encode($billing_email);
+  $headers = array(
+    'Content-Type' => 'application/json',
+    'Authorization' => 'Basic ' . $auth_token,
+    'x-api-key' => $auth_token,
+  );
+  $options = array(
+    'method' => 'POST',
+    'headers' => $headers,
+    'data' => json_encode($data),
+  );
+
+  $response = drupal_http_request($url, $options);
+  switch ($response->code) {
+    case 200:
+      $message = 'Tag1 D7ES information transmitted successfully.';
+      watchdog(
+        'tag1_d7es',
+        $message,
+        array(),
+        WATCHDOG_INFO
+      );
+      variable_set('tag1_d7es_phone_home', REQUEST_TIME);
+      if ($display_messages) {
+        drupal_set_message($message, 'status');
+      }
+      return TRUE;
+
+    case 403:
+      $message = 'Authentication error. Please review the billing address and API endpoint (if configured).';
+      watchdog(
+        'tag1_d7es',
+        $message,
+        array(),
+        WATCHDOG_ERROR
+      );
+      if ($display_messages) {
+        drupal_set_message($message, 'error');
+      }
+      return FALSE;
+
+    default:
+      $variables = array(
+        '%response_code' => $response->code,
+        '%message' => '',
+        '%error' => '',
+      );
+      $error_data = json_decode($response->data);
+      if (isset($error_data->message)) {
+        $variables['%message'] = $error_data->message;
+      }
+      if (isset($error_data->error)) {
+        $variables['%error'] = $error_data->error;
+      }
+      watchdog(
+        'tag1_d7es',
+        'Failure sending information to Tag1 D7ES: "%response_code %message %error".',
+        $variables,
+        WATCHDOG_ERROR
+      );
+      if ($display_messages) {
+        drupal_set_message(t('Module report failed to submit. Please review the site error logs for more information.'), 'error');
+      }
+  }
+  return FALSE;
+}
+
+/**
+ * Build the phone-home payload.
+ *
+ * @param string $site_id
+ *   Pass the site ID if it's already known.
+ * @param string $billing_email
+ *   Pass the billing email if it's already known.
+ *
+ * @return array
+ *   The data array for the request.
+ */
+function _tag1_d7es_payload($site_id = '', $billing_email = '') {
+  if (!$site_id) {
+    $site_id = variable_get('tag1_d7es_site_id');
+  }
+  if (!$billing_email) {
+    $billing_email = variable_get('tag1_d7es_billing_email');
+  }
+  $data = _tag1_d7es_runtime_info() + array(
+    'siteId' => $site_id,
+    'timestamp' => REQUEST_TIME,
+    'siteUrl' => $GLOBALS['base_url'],
+    'billingEmail' => $billing_email,
+  );
+
+  // Email addresses are optional.
+  $data['emails'] = array();
+  $emails = variable_get('tag1_d7es_email_addresses', NULL);
+  if ($emails) {
+    $data['emails'] = array_map('trim', explode(',', $emails));
+  }
+
+  // Add module and theme data.
+  $data['modules'] = _tag1_d7es_project_info(system_rebuild_module_data());
+  $data['themes'] = _tag1_d7es_project_info(system_rebuild_theme_data());
+
+  // Add platform-specific data.
+  if (tag1_d7es_detect_platform() == TAG1_D7ES_PLATFORM_PANTHEON) {
+    if (getenv('PANTHEON_SITE')) {
+      $data['pantheonSiteId'] = getenv('PANTHEON_SITE');
+    }
+    if (getenv('PANTHEON_DEPLOYMENT_IDENTIFIER')) {
+      $data['pantheonBuildId'] = getenv('PANTHEON_DEPLOYMENT_IDENTIFIER');
+    }
+  }
+
+  return $data;
+}
+
+/**
+ * Determine the endpoint to use.
+ *
+ * @return string
+ *   The URL for the API endpoint.
+ */
+function _tag1_d7es_get_endpoint() {
+  return variable_get('tag1_d7es_endpoint', TAG1_D7ES_ENDPOINT);
+}
+
+/**
+ * Build module/theme information.
+ *
+ * @param array $projects
+ *   A list of projects returned by system_rebuild_module_data() and
+ *   system_rebuild_theme_data().
+ *
+ * @return array
+ *   Parsed data array for projects.
+ */
+function _tag1_d7es_project_info(array $projects) {
+  $data = [];
+
+  // Remove hidden and core projects.
+  foreach ($projects as $project) {
+    if (!isset($project->info['hidden']) && (!isset($project->info['package']) || $project->info['package'] != 'Core')) {
+      $data[] = array(
+        'name' => $project->name,
+        'version' => isset($project->info['version']) ? $project->info['version'] : '',
+        'enabled' => (bool) $project->status,
+      );
+    }
+  }
+
+  return $data;
+}
+
+/**
+ * Build system runtime information.
+ *
+ * @return array
+ *   Specific runtime information to include with the data payload.
+ */
+function _tag1_d7es_runtime_info() {
+  // Map runtime string identifier with desired $data key.
+  $key_mapping = array(
+    'drupal' => 'core',
+    'database_system_version' => 'dbVersion',
+  );
+
+  // Poll runtime information. See system_status();
+  include_once DRUPAL_ROOT . '/includes/install.inc';
+  drupal_load_updates();
+  $runtime = module_invoke('system', 'requirements', 'runtime');
+
+  // Build data array.
+  $data = array();
+  foreach ($key_mapping as $key => $value) {
+    if (array_key_exists($key, $runtime)) {
+      $data[$value] = $runtime[$key]['value'];
+    }
+  }
+
+  // Easier to add PHP info directly.
+  $data['php'] = phpversion();
+
+  return $data;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function tag1_d7es_menu() {
+  $items['admin/config/system/tag1-d7es'] = array(
+    'title' => 'Tag1 D7ES',
+    'description' => 'Configure the credentials and notification settings for Tag1 D7ES.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('tag1_d7es_admin_form'),
+    'access arguments' => array('administer site configuration'),
+  );
+  return $items;
+}
+
+/**
+ * Form constructor for the tag1_d7es system settings.
+ *
+ * @see tag1_d7es_admin_form_submit()
+ * @ingroup forms
+ */
+function tag1_d7es_admin_form($form, $form_state) {
+  $form['description'] = array(
+    '#type' => 'markup',
+    '#markup' => '<p>' . t("Configure this module to communicate with Tag1's D7ES service. Installation and use of this module constitutes your acceptance of and agreement to be bound by Tag1 Consulting Inc's Terms of Service and Privacy Policy, as published at <a href='https://d7es.tag1.com/'>D7ES.Tag1.com</a>") . '</p>',
+  );
+
+  // The billing email address is only needed for non-platform customers.
+  $form['tag1_d7es_billing_email'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Billing email address'),
+    '#size' => 80,
+    '#maxlength' => 255,
+    '#default_value' => variable_get('tag1_d7es_billing_email', ''),
+    '#required' => TRUE,
+    '#description' => t('The primary billing email address.'),
+    '#access' => !(tag1_d7es_detect_platform()),
+  );
+
+  $form['tag1_d7es_email_addresses'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Notification email addresses'),
+    '#size' => 80,
+    '#maxlength' => 255,
+    '#default_value' => variable_get('tag1_d7es_email_addresses', ''),
+    '#required' => TRUE,
+    '#description' => t('A comma-separated list of email addresses that should receive notifications about available updates.'),
+  );
+
+  $form['tag1_d7es_send_update_emails'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Continue to send core "Available updates" notifications.'),
+    '#access' => module_exists('update') && variable_get('update_notify_emails'),
+    '#description' => t('To prevent duplicate email notifications of an update, this module disables the emails from the <a href="/admin/reports/updates/settings">Update Status module</a> by default.'),
+    '#default_value' => variable_get('tag1_d7es_send_update_emails', 0),
+  );
+
+  $form['advanced'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced'),
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
+  );
+  $form['advanced']['tag1_d7es_site_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Site ID'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('tag1_d7es_site_id', ''),
+    '#description' => t('A UUID created on module installation that is specific to your site. In regular operations this value should not need to be changed.'),
+  );
+  $form['advanced']['tag1_d7es_endpoint'] = array(
+    '#type' => 'textfield',
+    '#title' => t('API Endpoint'),
+    '#default_value' => variable_get('tag1_d7es_endpoint'),
+    '#description' => t('A different API endpoint to use (typically for testing purposes). In regular operations this value should not need to be changed.'),
+  );
+
+  $form['advanced']['drush_endpoint'] = array(
+    '#type' => 'markup',
+    '#markup' => '<label>' . t('Drush release XML source') . '</label>
+<code>' . tag1_d7es_personalize_drush_source_endpoint() . '</code>
+<div class="description">You can use this URL to <a href="https://docs.tag1.com/setup/#configuring-drush">configure Drush for updates</a></div>',
+    '#access' => (variable_get('update_fetch_url') && !tag1_d7es_detect_platform()),
+  );
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+  );
+
+  $form['debugging'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Debugging'),
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
+  );
+  $form['debugging']['payload'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Payload'),
+    '#default_value' => json_encode(_tag1_d7es_payload()),
+  );
+
+  $form['#validate'][] = 'tag1_d7es_admin_form_validate';
+
+  return $form;
+}
+
+/**
+ * Form validation handler for tag1_d7es_admin_form().
+ */
+function tag1_d7es_admin_form_validate($form, &$form_state) {
+  if (!tag1_d7es_uuid_is_valid($form_state['values']['tag1_d7es_site_id'])) {
+    form_set_error('tag1_d7es_site_id', t('The Site ID is not a valid UUID.'));
+  }
+}
+
+/**
+ * Form submission handler for tag1_d7es_admin_form().
+ */
+function tag1_d7es_admin_form_submit($form, &$form_state) {
+  // If the module is freshly installed, or if the billing address or API
+  // endpoint has changed, verify that we can make a request to the API.
+  if (
+    !drupal_valid_test_ua() && (
+      variable_get('tag1_d7es_phone_home') === 0 ||
+      $form_state['values']['tag1_d7es_billing_email'] != variable_get('tag1_d7es_billing_email') ||
+      (isset($form_state['values']['tag1_d7es_endpoint']) && $form_state['values']['tag1_d7es_endpoint'] != _tag1_d7es_get_endpoint())
+    )
+  ) {
+    $submitted_billing_email = $form_state['values']['tag1_d7es_billing_email'];
+    $submitted_api_endpoint = $form_state['values']['tag1_d7es_endpoint'] ?: TAG1_D7ES_ENDPOINT;
+    $preflight = tag1_d7es_preflight($form_state['values']['tag1_d7es_site_id'], $submitted_billing_email, TRUE);
+    if ($preflight) {
+      $data = _tag1_d7es_payload($form_state['values']['tag1_d7es_site_id'], $form_state['values']['tag1_d7es_billing_email']);
+      $success = _tag1_d7es_transmit($submitted_billing_email, $data, TRUE, $submitted_api_endpoint);
+      if ($success) {
+        variable_set('tag1_d7es_phone_home', REQUEST_TIME);
+        variable_set('update_fetch_url', tag1_d7es_personalize_updates_endpoint($submitted_billing_email));
+      }
+    }
+  }
+
+  system_settings_form_submit($form, $form_state);
+  if ($form_state['values']['tag1_d7es_endpoint'] === '' || $form_state['values']['tag1_d7es_endpoint'] === TAG1_D7ES_ENDPOINT) {
+    variable_del('tag1_d7es_endpoint');
+  }
+
+}
+
+/**
+ * Determine the customer-specific Release XML endpoint.
+ *
+ * @param string $billing_email
+ *   The billing email address for personalization.
+ */
+function tag1_d7es_personalize_updates_endpoint($billing_email = '') {
+  if (!$billing_email) {
+    $billing_email = variable_get('tag1_d7es_billing_email');
+  }
+  $base_url = TAG1_D7ES_UPDATES_ENDPOINT;
+  $auth = $billing_email . ':' . base64_encode($billing_email) . '@';
+  return substr_replace($base_url, $auth, (strpos($base_url, '//') + 2), 0);
+}
+
+/**
+ * Determine the customer-specific Drush source XML endpoint.
+ *
+ * @param string $billing_email
+ *   The billing email address for personalization.
+ */
+function tag1_d7es_personalize_drush_source_endpoint($billing_email = '') {
+  if (!$billing_email) {
+    $billing_email = variable_get('tag1_d7es_billing_email', '');
+  }
+  $base_url = TAG1_D7ES_UPDATES_ENDPOINT;
+  $auth = urlencode($billing_email) . ':' . urlencode(base64_encode($billing_email)) . '@';
+  return substr_replace($base_url, $auth, (strpos($base_url, '//') + 2), 0);
+}
+
+/**
+ * Determine if this is a platform-level customer.
+ *
+ * @return string|bool
+ *   Returns the platform name if detected, FALSE otherwise.
+ */
+function tag1_d7es_detect_platform() {
+  if (getenv('PANTHEON_ENVIRONMENT') && getenv('PANTHEON_D7ES_API_KEY')) {
+    return TAG1_D7ES_PLATFORM_PANTHEON;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Wrapper function to create UUIDs.
+ *
+ * Uses ctools or the UUID module if either is enabled. Like in
+ * ctools_uuid_generate(), we are copying this from the ctools and uuid modules.
+ *
+ * @see http://php.net/uniqid#65879
+ *
+ * @return string
+ *   A generated UUID.
+ */
+function tag1_d7es_uuid_generate() {
+  if (module_exists('ctools')) {
+    return ctools_uuid_generate();
+  }
+  elseif (module_exists('uuid')) {
+    return uuid_generate();
+  }
+  else {
+    module_load_include('inc', 'tag1_d7es', 'includes/uuid');
+
+    $callback = &drupal_static(__FUNCTION__);
+
+    if (empty($callback)) {
+      if (function_exists('uuid_create') && !function_exists('uuid_make')) {
+        $callback = '_tag1_d7es_uuid_generate_pecl';
+      }
+      elseif (function_exists('com_create_guid')) {
+        $callback = '_tag1_d7es_uuid_generate_com';
+      }
+      else {
+        $callback = '_tag1_d7es_uuid_generate_php';
+      }
+    }
+    return $callback();
+  }
+}
+
+/**
+ * Check that a string is in the format of a UUID. Copied from CTools.
+ *
+ * @param string $uuid
+ *   The string to test.
+ *
+ * @return bool
+ *   TRUE if the string is well-formed.
+ *
+ * @see http://drupal.org/project/ctools
+ * @see http://drupal.org/project/uuid
+ */
+function tag1_d7es_uuid_is_valid($uuid = '') {
+  if (empty($uuid)) {
+    return FALSE;
+  }
+  if (module_exists('ctools')) {
+    return ctools_uuid_is_valid($uuid);
+  }
+  elseif (function_exists('uuid_is_valid') || module_exists('uuid')) {
+    return uuid_is_valid($uuid);
+  }
+  else {
+    module_load_include('inc', 'tag1_d7es', 'includes/uuid');
+    return uuid_is_valid($uuid);
+  }
+}
+
+/**
+ * Implements hook_mail_alter().
+ */
+function tag1_d7es_mail_alter(&$message) {
+  if ($message['id'] == 'update_status_notify') {
+    if (variable_get('tag1_d7es_send_update_emails', 0) !== 1) {
+      $message['send'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Determine if the subscription is still active.
+ *
+ * @return bool
+ *   Whether the subscription should be considered active.
+ */
+function tag1_d7es_subscription_is_active() {
+  // We expect the module to report successfully at least once per week.
+  return variable_get('tag1_d7es_phone_home', 0) >= REQUEST_TIME - (TAG1_D7ES_PHONE_HOME_PERIOD * 7);
+}
+
+/**
+ * Implements hook_update_status_alter().
+ */
+function tag1_d7es_update_status_alter(&$projects) {
+  $available = update_get_available();
+  foreach ($projects as &$project_data) {
+    if (tag1_d7es_subscription_is_active()) {
+      // All projects from Drupal.org will have this status at D7 EOL.
+      if ($project_data['status'] === UPDATE_NOT_SUPPORTED) {
+        // See if we can determine an updated release.
+        unset($project_data['status']);
+        unset($project_data['extra']);
+
+        // BEGIN from update_calculate_project_update_status().
+        // Figure out the target major version.
+        $existing_major = $project_data['existing_major'];
+        $supported_majors = array();
+        if (isset($available[$project_data['name']]['supported_majors'])) {
+          $supported_majors = explode(',', $available[$project_data['name']]['supported_majors']);
+        }
+        elseif (isset($available[$project_data['name']]['default_major'])) {
+          // Older release history XML file without supported or recommended.
+          $supported_majors[] = $available[$project_data['name']]['default_major'];
+        }
+
+        if (in_array($existing_major, $supported_majors)) {
+          // Still supported, stay at the current major version.
+          $target_major = $existing_major;
+        }
+        elseif (isset($available[$project_data['name']]['recommended_major'])) {
+          // Since 'recommended_major' is defined, we know this is the new XML
+          // format. Therefore, we know the current release is unsupported since
+          // its major version was not in the 'supported_majors' list. We should
+          // find the best release from the recommended major version.
+          $target_major = $available[$project_data['name']]['recommended_major'];
+          $project_data['status'] = UPDATE_NOT_SUPPORTED;
+        }
+        elseif (isset($available[$project_data['name']]['default_major'])) {
+          // Older release history XML file without recommended, so recommend
+          // the currently defined "default_major" version.
+          $target_major = $available[$project_data['name']]['default_major'];
+        }
+        else {
+          // Malformed XML file? Stick with the current version.
+          $target_major = $existing_major;
+        }
+
+        // Make sure we never tell the admin to downgrade. If we recommended an
+        // earlier version than the one they're running, they'd face an
+        // impossible data migration problem, since Drupal never supports a DB
+        // downgrade path. In the unfortunate case that what they're running is
+        // unsupported, and there's nothing newer for them to upgrade to, we
+        // can't print out a "Recommended version", but just have to tell them
+        // what they have is unsupported and let them figure it out.
+        $target_major = max($existing_major, $target_major);
+
+        $release_patch_changed = '';
+        $patch = '';
+
+        // If the project is marked as UPDATE_FETCH_PENDING, it means that the
+        // data we currently have (if any) is stale, and we've got a task queued
+        // up to (re)fetch the data. In that case, we mark it as such, merge in
+        // whatever data we have (e.g. project title and link), and move on.
+        if (!empty($available[$project_data['name']]['fetch_status']) && $available[$project_data['name']]['fetch_status'] == UPDATE_FETCH_PENDING) {
+          $project_data['status'] = UPDATE_FETCH_PENDING;
+          $project_data['reason'] = t('No available update data');
+          $project_data['fetch_status'] = $available[$project_data['name']]['fetch_status'];
+          return;
+        }
+
+        // Defend ourselves from XML history files that contain no releases.
+        if (empty($available[$project_data['name']]['releases'])) {
+          $project_data['status'] = UPDATE_UNKNOWN;
+          $project_data['reason'] = t('No available releases found');
+          return;
+        }
+        foreach ($available[$project_data['name']]['releases'] as $version => $release) {
+          // First, if this is the existing release, check a few conditions.
+          if ($project_data['existing_version'] === $version) {
+            if (isset($release['terms']['Release type']) &&
+              in_array('Insecure', $release['terms']['Release type'])) {
+              $project_data['status'] = UPDATE_NOT_SECURE;
+            }
+            elseif ($release['status'] == 'unpublished') {
+              $project_data['status'] = UPDATE_REVOKED;
+              if (empty($project_data['extra'])) {
+                $project_data['extra'] = array();
+              }
+              $project_data['extra'][] = array(
+                'class' => array('release-revoked'),
+                'label' => t('Release revoked'),
+                'data' => t('Your currently installed release has been revoked, and is no longer available for download. Disabling everything included in this release or upgrading is strongly recommended!'),
+              );
+            }
+            elseif (isset($release['terms']['Release type']) &&
+              in_array('Unsupported', $release['terms']['Release type'])) {
+              $project_data['status'] = UPDATE_NOT_SUPPORTED;
+              if (empty($project_data['extra'])) {
+                $project_data['extra'] = array();
+              }
+              $project_data['extra'][] = array(
+                'class' => array('release-not-supported'),
+                'label' => t('Release not supported'),
+                'data' => t('Your currently installed release is now unsupported, and is no longer available for download. Disabling everything included in this release or upgrading is strongly recommended!'),
+              );
+            }
+          }
+
+          // Otherwise, ignore unpublished, insecure, or unsupported releases.
+          if ($release['status'] == 'unpublished' ||
+            (isset($release['terms']['Release type']) &&
+              (in_array('Insecure', $release['terms']['Release type']) ||
+                in_array('Unsupported', $release['terms']['Release type'])))) {
+            continue;
+          }
+
+          // See if this is a higher major version than our target and yet still
+          // supported. If so, record it as an "Also available" release.
+          // Note: some projects have a HEAD release from CVS days, which could
+          // be one of those being compared. They would not have version_major
+          // set, so we must call isset first.
+          if (isset($release['version_major']) && $release['version_major'] > $target_major) {
+            if (in_array($release['version_major'], $supported_majors)) {
+              if (!isset($project_data['also'])) {
+                $project_data['also'] = array();
+              }
+              if (!isset($project_data['also'][$release['version_major']])) {
+                $project_data['also'][$release['version_major']] = $version;
+                $project_data['releases'][$version] = $release;
+              }
+            }
+            // Otherwise, this release can't matter to us, since it's neither
+            // from the release series we're currently using nor the recommended
+            // release. We don't even care about security updates for this
+            // branch, since if a project maintainer puts out a security release
+            // at a higher major version and not at the lower major version,
+            // they must remove the lower version from the supported major
+            // versions at the same time, in which case we won't hit this code.
+            continue;
+          }
+
+          // Look for the 'latest version' if we haven't found it yet. Latest is
+          // defined as the most recent version for the target major version.
+          if (!isset($project_data['latest_version'])
+            && $release['version_major'] == $target_major) {
+            $project_data['latest_version'] = $version;
+            $project_data['releases'][$version] = $release;
+          }
+
+          // Look for the development snapshot release for this branch.
+          if (!isset($project_data['dev_version'])
+            && $release['version_major'] == $target_major
+            && isset($release['version_extra'])
+            && $release['version_extra'] == 'dev') {
+            $project_data['dev_version'] = $version;
+            $project_data['releases'][$version] = $release;
+          }
+
+          // Look for the 'recommended' version if we haven't found it yet (see
+          // phpdoc at the top of this function for the definition).
+          if (!isset($project_data['recommended'])
+            && $release['version_major'] == $target_major
+            && isset($release['version_patch'])) {
+            if ($patch != $release['version_patch']) {
+              $patch = $release['version_patch'];
+              $release_patch_changed = $release;
+            }
+            if (empty($release['version_extra']) && $patch == $release['version_patch']) {
+              $project_data['recommended'] = $release_patch_changed['version'];
+              $project_data['releases'][$release_patch_changed['version']] = $release_patch_changed;
+            }
+          }
+
+          // Stop searching once we hit the currently installed version.
+          if ($project_data['existing_version'] === $version) {
+            break;
+          }
+
+          // If we're running a dev snapshot and have a timestamp, stop
+          // searching for security updates once we hit an official release
+          // older than what we've got. Allow 100 seconds of leeway to handle
+          // differences between the datestamp in the .info file and the
+          // timestamp of the tarball itself (which are usually off by 1 or 2
+          // seconds) so that we don't flag that as a new release.
+          if ($project_data['install_type'] == 'dev') {
+            if (empty($project_data['datestamp'])) {
+              // We don't have current timestamp info, so we can't know.
+              continue;
+            }
+            elseif (isset($release['date']) && ($project_data['datestamp'] + 100 > $release['date'])) {
+              // We're newer than this, so we can skip it.
+              continue;
+            }
+          }
+
+          // See if this release is a security update.
+          if (isset($release['terms']['Release type'])
+            && in_array('Security update', $release['terms']['Release type'])) {
+            $project_data['security updates'][] = $release;
+          }
+        }
+
+        // If we were unable to find a recommended version, then make the latest
+        // version the recommended version if possible.
+        if (!isset($project_data['recommended']) && isset($project_data['latest_version'])) {
+          $project_data['recommended'] = $project_data['latest_version'];
+        }
+
+        // Check to see if we need an update or not.
+        if (!empty($project_data['security updates'])) {
+          // If we found security updates, that always trumps any other status.
+          $project_data['status'] = UPDATE_NOT_SECURE;
+        }
+
+        if (isset($project_data['status'])) {
+          // If we already know the status, we're done.
+          return;
+        }
+
+        // If we don't know what to recommend, there's nothing we can report.
+        // Bail out early.
+        if (!isset($project_data['recommended'])) {
+          $project_data['status'] = UPDATE_UNKNOWN;
+          $project_data['reason'] = t('No available releases found');
+          return;
+        }
+
+        // If we're running a dev snapshot, compare the date of the dev snapshot
+        // with the latest official version, and record the absolute latest in
+        // 'latest_dev' so we can correctly decide if there's a newer release
+        // than our current snapshot.
+        if ($project_data['install_type'] == 'dev') {
+          if (isset($project_data['dev_version']) && $available[$project_data['name']]['releases'][$project_data['dev_version']]['date'] > $available[$project_data['name']]['releases'][$project_data['latest_version']]['date']) {
+            $project_data['latest_dev'] = $project_data['dev_version'];
+          }
+          else {
+            $project_data['latest_dev'] = $project_data['latest_version'];
+          }
+        }
+
+        // Figure out the status, based on what we've seen and the install type.
+        switch ($project_data['install_type']) {
+          case 'official':
+            if ($project_data['existing_version'] === $project_data['recommended'] || $project_data['existing_version'] === $project_data['latest_version']) {
+              $project_data['status'] = UPDATE_CURRENT;
+            }
+            else {
+              $project_data['status'] = UPDATE_NOT_CURRENT;
+            }
+            break;
+
+          case 'dev':
+            $latest = $available[$project_data['name']]['releases'][$project_data['latest_dev']];
+            if (empty($project_data['datestamp'])) {
+              $project_data['status'] = UPDATE_NOT_CHECKED;
+              $project_data['reason'] = t('Unknown release date');
+            }
+            elseif (($project_data['datestamp'] + 100 > $latest['date'])) {
+              $project_data['status'] = UPDATE_CURRENT;
+            }
+            else {
+              $project_data['status'] = UPDATE_NOT_CURRENT;
+            }
+            break;
+
+          default:
+            $project_data['status'] = UPDATE_UNKNOWN;
+            $project_data['reason'] = t('Invalid info');
+        }
+        // END from update_calculate_project_update_status().
+      }
+    }
+    else {
+      // Module is enabled but subscription has lapsed.
+      if (in_array($project_data['status'], [UPDATE_NOT_SECURE, UPDATE_NOT_CURRENT])) {
+        if (isset($project_data['recommended'])) {
+          $version = $project_data['recommended'];
+        }
+        elseif (isset($project_data['latest_version'])) {
+          $version = $project_data['latest_version'];
+        }
+        else {
+          $version = NULL;
+        }
+        if ($version && isset($project_data['releases']) && isset($project_data['releases'][$version])) {
+          $release = $project_data['releases'][$version];
+          if (isset($release['terms']['Release type']) &&
+            in_array('Tag1 D7ES', $release['terms']['Release type'])) {
+            $project_data['status'] = UPDATE_NOT_SUPPORTED;
+          }
+        }
+      }
+    }
+
+    // Handle projects that we specify as Insecure via our update XML.
+    if ($project_data['status'] === UPDATE_NOT_SECURE && !isset($project_data['recommended'])) {
+      // Switch to more generic messaging.
+      $project_data['status'] = UPDATE_NOT_SUPPORTED;
+      if (isset($available[$project_data['name']]['recommended_alternative']) && tag1_d7es_subscription_is_active()) {
+        $message = $available[$project_data['name']]['recommended_alternative'];
+      }
+      else {
+        $message = t('This project is no longer supported, and is no longer available for download. Disabling everything included by this project is strongly recommended!');
+      }
+      $project_data['extra'] = array(
+        array(
+          'class' => array('project-not-supported'),
+          'label' => t('Project not supported'),
+          'data' => $message,
+        ),
+      );
+    }
+
+  }
+}
+
+/**
+ * Return the recommended release from the fetched project data.
+ *
+ * @param array $project
+ *   Project information.
+ *
+ * @return array
+ *   Parsed release data.
+ */
+function _tag1_d7es_get_release_data(array $project) {
+  $version = isset($project['recommended']) ? $project['recommended'] : $project['latest_version'];
+  if ($release = $project['releases'][$version]) {
+    return $release;
+  }
+  return array();
+}

--- a/modules/path/path.module
+++ b/modules/path/path.module
@@ -41,6 +41,7 @@ function path_permission() {
   return array(
     'administer url aliases' => array(
       'title' => t('Administer URL aliases'),
+      'restrict access' => TRUE,
     ),
     'create url aliases' => array(
       'title' => t('Create and edit URL aliases'),

--- a/modules/simpletest/simpletest.pages.inc
+++ b/modules/simpletest/simpletest.pages.inc
@@ -443,7 +443,7 @@ function simpletest_settings_form($form, &$form_state) {
   $form['general']['simpletest_clear_results'] = array(
     '#type' => 'checkbox',
     '#title' => t('Clear results after each complete test suite run'),
-    '#description' => t('By default SimpleTest will clear the results after they have been viewed on the results page, but in some cases it may be useful to leave the results in the database. The results can then be viewed at <em>admin/config/development/testing/[test_id]</em>. The test ID can be found in the database, simpletest table, or kept track of when viewing the results the first time. Additionally, some modules may provide more analysis or features that require this setting to be disabled.'),
+    '#description' => t('By default SimpleTest will clear the results after they have been viewed on the results page, but in some cases it may be useful to leave the results in the database. The results can then be viewed at <em>admin/config/development/testing/results/[test_id]</em>. The test ID can be found in the database, simpletest table, or kept track of when viewing the results the first time. Additionally, some modules may provide more analysis or features that require this setting to be disabled.'),
     '#default_value' => variable_get('simpletest_clear_results', TRUE),
   );
   $form['general']['simpletest_verbose'] = array(

--- a/modules/simpletest/tests/bootstrap.test
+++ b/modules/simpletest/tests/bootstrap.test
@@ -963,3 +963,62 @@ class BootstrapDrupalCacheArrayTestCase extends DrupalWebTestCase {
     $this->assertTrue(is_string($payload2) && (strpos($payload2, 'phpinfo') !== FALSE), 'DrupalCacheArray persisted data to cache_form.');
   }
 }
+
+/**
+ * Test the trusted HTTP host configuration.
+ */
+class BootstrapTrustedHostsTestCase extends DrupalUnitTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Trusted HTTP host test',
+      'description' => 'Tests the trusted_host_patterns configuration.',
+      'group' => 'Bootstrap',
+    );
+  }
+
+  /**
+   * Tests hostname validation.
+   *
+   * @see drupal_check_trusted_hosts()
+   */
+  function testTrustedHosts() {
+    $trusted_host_patterns = array(
+      '^example\.com$',
+      '^.+\.example\.com$',
+      '^example\.org',
+      '^.+\.example\.org',
+    );
+
+    foreach ($this->providerTestTrustedHosts() as $data) {
+      $test = array_combine(array('host', 'message', 'expected'), $data);
+      $valid_host = drupal_check_trusted_hosts($test['host'], $trusted_host_patterns);
+      $this->assertEqual($test['expected'], $valid_host, $test['message']);
+    }
+  }
+
+  /**
+   * Provides test data for testTrustedHosts().
+   */
+  public function providerTestTrustedHosts() {
+    $data = array();
+
+    // Tests canonical URL.
+    $data[] = array('www.example.com', 'canonical URL is trusted', TRUE);
+
+    // Tests missing hostname for HTTP/1.0 compatability where the Host
+    // header is optional.
+    $data[] = array(NULL, 'empty Host is valid', TRUE);
+
+    // Tests the additional patterns from the settings.
+    $data[] = array('example.com', 'host from settings is trusted', TRUE);
+    $data[] = array('subdomain.example.com', 'host from settings is trusted', TRUE);
+    $data[] = array('www.example.org', 'host from settings is trusted', TRUE);
+    $data[] = array('example.org', 'host from settings is trusted', TRUE);
+
+    // Tests mismatch.
+    $data[] = array('www.blackhat.com', 'unspecified host is untrusted', FALSE);
+
+    return $data;
+  }
+}

--- a/modules/simpletest/tests/cache.test
+++ b/modules/simpletest/tests/cache.test
@@ -303,20 +303,6 @@ class CacheClearCase extends CacheTestCase {
 
     $this->assertTrue($this->checkCacheExists('test_cid_clear3', $this->default_value),
                       'Entry was not cleared from the cache');
-
-    // Set the cache clear threshold to 2 to confirm that the full bin is cleared
-    // when the threshold is exceeded.
-    variable_set('cache_clear_threshold', 2);
-    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
-    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
-    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
-                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
-                      'Two cache entries were created.');
-    cache_clear_all(array('test_cid_clear1', 'test_cid_clear2', 'test_cid_clear3'), $this->default_bin);
-    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value)
-                       || $this->checkCacheExists('test_cid_clear2', $this->default_value)
-                       || $this->checkCacheExists('test_cid_clear3', $this->default_value),
-                       'All cache entries removed when the array exceeded the cache clear threshold.');
   }
 
   /**

--- a/modules/simpletest/tests/error.test
+++ b/modules/simpletest/tests/error.test
@@ -103,6 +103,15 @@ class DrupalErrorHandlerTestCase extends DrupalWebTestCase {
   function assertErrorMessage(array $error) {
     $message = t('%type: !message in %function (line ', $error);
     $this->assertRaw($message, format_string('Found error message: !message.', array('!message' => $message)));
+
+    // Also check that no full path from the error is displayed.
+    $this->assertNoRaw($error['%file'], format_string('Full path from error not displayed: %file.', array('%file' => $error['%file'])));
+
+    // Check that the path was displayed with the DRUPAL_ROOT hidden.
+    $root_length = strlen(DRUPAL_ROOT);
+    $stripped_path = substr($error['%file'], $root_length + 1);
+    $sanitized_path = t('of %path)', array('%path' => $stripped_path));
+    $this->assertRaw($sanitized_path, 'Path in error message was sanitized.');
   }
 
   /**
@@ -111,5 +120,8 @@ class DrupalErrorHandlerTestCase extends DrupalWebTestCase {
   function assertNoErrorMessage(array $error) {
     $message = t('%type: !message in %function (line ', $error);
     $this->assertNoRaw($message, format_string('Did not find error message: !message.', array('!message' => $message)));
+
+    // Also check that no full path from the error is displayed.
+    $this->assertNoRaw($error['%file'], format_string('Full path from error not displayed: %file.', array('%file' => $error['%file'])));
   }
 }

--- a/modules/simpletest/tests/password.test
+++ b/modules/simpletest/tests/password.test
@@ -73,6 +73,7 @@ class PasswordHashingTest extends DrupalWebTestCase {
     $result = user_hash_password($password);
     $this->assertFalse(empty($result), '510 byte long password is allowed.');
     $password .= 'xx';
+    $result = user_hash_password($password);
     $this->assertFalse(empty($result), '512 byte long password is allowed.');
     $password = str_repeat('€', 171);
     $result = user_hash_password($password);

--- a/modules/simpletest/tests/session.test
+++ b/modules/simpletest/tests/session.test
@@ -779,8 +779,10 @@ class SessionHttpsTestCase extends DrupalWebTestCase {
     $form[0]['action'] = $this->httpsUrl('user');
     $this->drupalPost(NULL, $edit, t('Log in'));
 
-    // Make the secure session cookie blank.
-    curl_setopt($this->curlHandle, CURLOPT_COOKIE, "$secure_session_name=");
+    // Make the secure session cookie blank. Closing the curl handler will stop
+    // the previous session ID from persisting.
+    $this->curlClose();
+    $this->additionalCurlOptions[CURLOPT_COOKIE] = rawurlencode($secure_session_name) . '=;';
     $this->drupalGet($this->httpsUrl('user'));
     $this->assertNoText($admin_user->name, 'User is not logged in as admin');
     $this->assertNoText($standard_user->name, "The user's own name is not displayed because the invalid session cookie has logged them out.");

--- a/modules/system/system.install
+++ b/modules/system/system.install
@@ -579,6 +579,27 @@ function system_requirements($phase) {
     }
   }
 
+  // See if trusted hostnames have been configured, and warn the user if they
+  // are not set.
+  if ($phase == 'runtime') {
+    $trusted_host_patterns = variable_get('trusted_host_patterns', array());
+    if (empty($trusted_host_patterns)) {
+      $requirements['trusted_host_patterns'] = array(
+        'title' => $t('Trusted Host Settings'),
+        'value' => $t('Not enabled'),
+        'description' => $t('The trusted_host_patterns setting is not configured in settings.php. This can lead to security vulnerabilities. It is <strong>highly recommended</strong> that you configure this. See <a href="@url">Protecting against HTTP HOST Header attacks</a> for more information.', array('@url' => 'https://www.drupal.org/node/1992030')),
+        'severity' => REQUIREMENT_ERROR,
+      );
+    }
+    else {
+      $requirements['trusted_host_patterns'] = array(
+        'title' => $t('Trusted Host Settings'),
+        'value' => $t('Enabled'),
+        'description' => $t('The trusted_host_patterns setting is set to allow %trusted_host_patterns', array('%trusted_host_patterns' => implode(', ', $trusted_host_patterns))),
+      );
+    }
+  }
+
   return $requirements;
 }
 

--- a/modules/system/system.mail.inc
+++ b/modules/system/system.mail.inc
@@ -21,10 +21,8 @@ class DefaultMailSystem implements MailSystemInterface {
   public function format(array $message) {
     // Join the body array into one string.
     $message['body'] = implode("\n\n", $message['body']);
-    // Convert any HTML to plain-text.
+    // Convert any HTML to plain-text and wrap the mail body for sending.
     $message['body'] = drupal_html_to_text($message['body']);
-    // Wrap the mail body for sending.
-    $message['body'] = drupal_wrap_mail($message['body']);
     return $message;
   }
 
@@ -64,7 +62,14 @@ class DefaultMailSystem implements MailSystemInterface {
     $mail_body = preg_replace('@\r?\n@', $line_endings, $message['body']);
     // For headers, PHP's API suggests that we use CRLF normally,
     // but some MTAs incorrectly replace LF with CRLF. See #234403.
-    $mail_headers = join("\n", $mimeheaders);
+    $headers_line_endings = variable_get('mail_headers_line_endings', "\n");
+    if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 80000 ) {
+      // PHP 8+ requires headers to be separated by CRLF, see:
+      // - https://bugs.php.net/bug.php?id=81158
+      // - https://github.com/php/php-src/commit/6983ae751cd301886c966b84367fc7aaa1273b2d#diff-c6922cd89f6f75912eb377833ca1eddb7dd41de088be821024b8a0e340fed3df
+      $headers_line_endings = variable_get('mail_headers_line_endings', "\r\n");
+    }
+    $mail_headers = join($headers_line_endings, $mimeheaders);
 
     // We suppress warnings and notices from mail() because of issues on some
     // hosts. The return value of this method will still indicate whether mail

--- a/modules/system/system.test
+++ b/modules/system/system.test
@@ -2937,6 +2937,21 @@ class SystemAdminTestCase extends DrupalWebTestCase {
     $this->drupalGet('');
     $this->assertTrue($this->cookies['Drupal.visitor.admin_compact_mode']['value'], 'Compact mode persists on new requests.');
   }
+
+  /**
+   * Test Trusted Host Settings message on the status report page.
+   */
+  function testTrustedHostSettingsMessage() {
+    $this->drupalGet('admin/reports/status');
+    $this->assertText('The trusted_host_patterns setting is not configured in settings.php.');
+    $this->assertNoText('The trusted_host_patterns setting is set to allow');
+
+    variable_set('trusted_host_patterns', array('a_trusted_pattern', 'another_trusted_pattern'));
+    $this->drupalGet('admin/reports/status');
+    $this->assertNoText('The trusted_host_patterns setting is not configured in settings.php.');
+    $this->assertText('The trusted_host_patterns setting is set to allow a_trusted_pattern, another_trusted_pattern');
+  }
+
 }
 
 /**

--- a/profiles/ug/ug.install
+++ b/profiles/ug/ug.install
@@ -84,7 +84,6 @@ function ug_update_7704(&$sandbox) {
  * Enable Tag1 D7ES module
  */
 function ug_update_7705(&$sandbox) {
-  $site_mail = variable_get('site_mail', '');
   module_enable(array('tag1_d7es'));
-  variable_set('tag1_d7es_email_addresses', $site_mail);
+  variable_set('tag1_d7es_email_addresses', 'wsadmin@uoguelph.ca');
 }

--- a/profiles/ug/ug.install
+++ b/profiles/ug/ug.install
@@ -79,3 +79,12 @@ function ug_update_7704(&$sandbox) {
     drupal_uninstall_modules(array('ug_video'));
   }
 }
+
+/**
+ * Enable Tag1 D7ES module
+ */
+function ug_update_7705(&$sandbox) {
+  $site_mail = variable_get('site_mail', '');
+  module_enable(array('tag1_d7es'));
+  variable_set('tag1_d7es_email_addresses', $site_mail);
+}

--- a/sites/default/default.settings.php
+++ b/sites/default/default.settings.php
@@ -648,6 +648,41 @@ $conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
 # $conf['allow_authorize_operations'] = FALSE;
 
 /**
+ * Trusted host configuration.
+ *
+ * Drupal can attempt to prevent HTTP Host header spoofing.
+ *
+ * To enable the trusted host mechanism, you enable your allowable hosts in
+ * $conf['trusted_host_patterns']. This should be an array of regular expression
+ * patterns, without delimiters, representing the hosts you would like to allow.
+ *
+ * For example, this code will allow the site to only run from www.example.com.
+ *
+ * @code
+ * $conf['trusted_host_patterns'] = array(
+ *   '^www\.example\.com$',
+ * );
+ * @endcode
+ *
+ * If you are running multisite, or if you are running your site from different
+ * domain names (for example, you don't redirect http://www.example.com to
+ * http://example.com), you should specify all of the host patterns that are
+ * allowed by your site.
+ *
+ * For example, this code will allow the site to run off of all variants of
+ * example.com and example.org, with all subdomains included.
+ *
+ * @code
+ * $conf['trusted_host_patterns'] = array(
+ *   '^example\.com$',
+ *   '^.+\.example\.com$',
+ *   '^example\.org',
+ *   '^.+\.example\.org',
+ * );
+ * @endcode
+ */
+
+/**
  * Theme debugging:
  *
  * When debugging is enabled:


### PR DESCRIPTION
- Add core updates from Pantheon that include D7 longterm support
- Add update hook that enables tag1_d7es module
- Use site_mail as email address to notify when module updates go out